### PR TITLE
Updated server version info printed in examples

### DIFF
--- a/content/clients/psql.md
+++ b/content/clients/psql.md
@@ -18,7 +18,7 @@ psql -h localhost -d $DBNAME -U $USERNAME
 ```
 
 ```
-psql (16.2 (Ubuntu 16.2-1ubuntu4), server 12.2 umbra v0.1-1779-gd3d7f00ff)
+psql (16.3 (Ubuntu 16.3-0ubuntu0.24.04.1))
 Type "help" for help.
 
 example=# 

--- a/content/cookbook/pgbench.md
+++ b/content/cookbook/pgbench.md
@@ -71,7 +71,7 @@ little load, but is mostly bound by the connection latency.
 pgbench -h /tmp -U postgres postgres -T 10 --protocol=prepared --builtin=select
 ```
 ```
-pgbench (15.6 (Ubuntu 15.6-0ubuntu0.23.10.1), server 12.2 umbra d2432c018)
+pgbench (16.3 (Ubuntu 16.3-0ubuntu0.24.04.1))
 starting vacuum...end.
 transaction type: <builtin: select only>
 scaling factor: 1
@@ -108,7 +108,7 @@ For typical consumer SSDs, this is >1ms, but enterprise SSDs can have lower writ
 pgbench -h /tmp -U postgres postgres -T 10 --protocol=prepared --builtin=simple-update
 ```
 ```
-pgbench (15.6 (Ubuntu 15.6-0ubuntu0.23.10.1), server 12.2 umbra d2432c018)
+pgbench (16.3 (Ubuntu 16.3-0ubuntu0.24.04.1))
 starting vacuum...end.
 transaction type: <builtin: simple update>
 scaling factor: 1


### PR DESCRIPTION
Apparently, psql and pgbench don't print the exact server version anymore, or at least if the server version is equal to the client version.
In any case, we want to remove any mention of umbra.