### PR TITLE
update all docs to refer to simplified docker setup

### DIFF
--- a/content/clients/grafana.md
+++ b/content/clients/grafana.md
@@ -58,7 +58,7 @@ In this example, we're assuming an empty database. If you already have a CedarDB
 ### Start CedarDB
 
 ```shell
-./server -createdb /home/dbs/grafanatest --address=:: # or omit 'createdb' if you already created the database earlier
+docker run --rm -p 5432:5432 -e CEDAR_PASSWORD=test --name cedardb_test cedardb
 ```
 
 ### Connect via psql and create a Grafana user
@@ -66,7 +66,7 @@ In this example, we're assuming an empty database. If you already have a CedarDB
 Connect to CedardB via [psql](/docs/clients/psql):
 
 ```shell
-psql -h /tmp -U postgres
+psql -h localhost -U postgres
 ```
 
 Create a new user for Grafana:

--- a/content/clients/js.md
+++ b/content/clients/js.md
@@ -75,7 +75,7 @@ const { default: pg } = await import("pg");
 const { Client } = pg;
 
 // Connect to CedarDB
-const client = new Client({host: '/tmp', user: 'postgres', database: 'postgres'});
+const client = new Client({host: 'localhost', user: 'postgres', database: 'postgres'});
 await client.connect();
 
 // Create a table and insert some data

--- a/content/cookbook/aurora_debezium.md
+++ b/content/cookbook/aurora_debezium.md
@@ -134,6 +134,10 @@ services:
      - type: bind
        source: /home/ubuntu/db
        target: /var/lib/cedardb/data
+    environment:
+     - CEDAR_USER=postgres
+     - CEDAR_PASSWORD=postgres
+     - CEDAR_DB=postgres
   connect:
     image: quay.io/debezium/connect:2.7
     ports:
@@ -158,18 +162,12 @@ Then, start all services with the following command:
 docker compose up
 ```
 
-### Connecting to and setting up CedarDB:
+### Install psql to talk to CedarDB and Postgres:
 
-We now need to create a user in CedarDB Debezium can use for replication.
-
-1. Install psql: `sudo apt install posgresql-common postgresql-client-16`
+```shell
+sudo apt install posgresql-common postgresql-client-16
+```
    
-2. Find the container id of the cedar image via `docker ps`: In my case it's `90ae1249bddb`.
-   
-3. Create the correct user in the docker image: `sudo docker exec -it 90ae psql -h /tmp -U postgres`
-   
-4. Set a password: `alter user postgres with password 'postgres';`
-
 
 ### Creating a Source and Sink Configuration for Debezium
 
@@ -287,7 +285,7 @@ INSERT INTO lineitem (lineitem_id,  transaction_id, product_id, quantity, unit_p
 
 ### Checking Replication in CedarDB
 
-Now connect to CedarDB (e.g., via `docker exec -it 90ae psql -h /tmp -U postgres`) and check the replicated table:
+Now connect to CedarDB (e.g., via `PGPASSWORD=postgres psql -h localhost -U postgres`) and check the replicated table:
 
 ```sql
 select * from lineitem;

--- a/content/cookbook/clickbench.md
+++ b/content/cookbook/clickbench.md
@@ -222,7 +222,7 @@ The ClickBench website shows the results as a minimum of three runs, which you c
 
 ```shell
 for i in {1..3}; do
-   psql -h /tmp -U postgres -c '\timing' -c "SELECT COUNT(DISTINCT UserID) FROM hits;" | grep 'Time';
+   psql -h localhost -U postgres -c '\timing' -c "SELECT COUNT(DISTINCT UserID) FROM hits;" | grep 'Time';
 done
 ```
 
@@ -231,7 +231,7 @@ done
 Now let's also do a full run with all queries and report the total time:
 
 ```shell
-cat <(echo '\\timing') queries.sql | psql -h /tmp -U postgres | grep 'Time' | awk '{print "Q" NR-1 " " $0; sum += $2;} END {print "Total: " sum " ms = " NR*60000/sum " qpm";}'
+cat <(echo '\\timing') queries.sql | psql -h localhost -U postgres | grep 'Time' | awk '{print "Q" NR-1 " " $0; sum += $2;} END {print "Total: " sum " ms = " NR*60000/sum " qpm";}'
 ```
 
 ```
@@ -291,7 +291,7 @@ Their results use the [geometric mean](https://en.wikipedia.org/wiki/Geometric_m
 You can use the following command to get comparable qpm numbers.
 
 ```shell
-cat <(echo '\\timing') queries.sql | psql -h /tmp -U postgres | grep 'Time' | awk '{sum += log($2);} END {print "Geometric mean: " exp(1)^(sum/NR) " ms = " 60000/exp(1)^(sum/NR) " qpm ";}'
+cat <(echo '\\timing') queries.sql | psql -h localhost -U postgres | grep 'Time' | awk '{sum += log($2);} END {print "Geometric mean: " exp(1)^(sum/NR) " ms = " 60000/exp(1)^(sum/NR) " qpm ";}'
 ```
 
 ```

--- a/content/cookbook/pgbench.md
+++ b/content/cookbook/pgbench.md
@@ -42,7 +42,7 @@ A scale factor of 100 thus inserts 10M rows with about 200MB of data.
 
 In addition to the scale, you also need to specify the connection parameters, username and database name:
 ```shell
-pgbench --initialize -h /tmp -U postgres postgres --scale=100
+pgbench --initialize -h localhost -U postgres postgres --scale=100
 ```
 ```
 dropping old tables...
@@ -68,7 +68,7 @@ This executes a simple in-memory primary-key lookup, which is not very taxing fo
 little load, but is mostly bound by the connection latency.
 
 ```shell
-pgbench -h /tmp -U postgres postgres -T 10 --protocol=prepared --builtin=select
+pgbench -h localhost -U postgres postgres -T 10 --protocol=prepared --builtin=select
 ```
 ```
 pgbench (16.3 (Ubuntu 16.3-0ubuntu0.24.04.1))
@@ -91,7 +91,7 @@ With many concurrent benchmark threads and connections, this workload becomes le
 picture that allows you to judge how the system scales in a read-heavy scenario:
 
 ```shell
-pgbench -h /tmp -U postgres postgres -T 10 --protocol=prepared --builtin=select --jobs=20 --client=200
+pgbench -h localhost -U postgres postgres -T 10 --protocol=prepared --builtin=select --jobs=20 --client=200
 ```
 ```
 tps = 1183279.095676 (without initial connection time)
@@ -105,7 +105,7 @@ This needs synchronous writes to storage.
 For typical consumer SSDs, this is >1ms, but enterprise SSDs can have lower write latency.
 
 ```shell
-pgbench -h /tmp -U postgres postgres -T 10 --protocol=prepared --builtin=simple-update
+pgbench -h localhost -U postgres postgres -T 10 --protocol=prepared --builtin=simple-update
 ```
 ```
 pgbench (16.3 (Ubuntu 16.3-0ubuntu0.24.04.1))
@@ -128,7 +128,7 @@ Again, scaling the number of concurrent writes allows much higher throughput, si
 bound.
 
 ```shell
-pgbench -h /tmp -U postgres postgres -T 10 --protocol=prepared --builtin=simple-update --jobs=20 --client=200
+pgbench -h localhost -U postgres postgres -T 10 --protocol=prepared --builtin=simple-update --jobs=20 --client=200
 ```
 ```
 tps = 45882.003693 (without initial connection time)


### PR DESCRIPTION
some docs still instructed users to
 - connect via domain socket
 - manually docker exec into containers to change credentials

this is no longer required with our new docker image. This commit simplifies the instructions accordingly