### PR TITLE
fix docker instructions

### DIFF
--- a/content/installation/_index.md
+++ b/content/installation/_index.md
@@ -36,7 +36,7 @@ Download
 Build the docker image using the Dockerfile downloaded from the link above.
 
 ```shell
-docker build --tag cedardb /path/to/Dockerfile/directory
+docker build --no-cache --tag cedardb .
 ```
 
 


### PR DESCRIPTION
Since the docker file does not change anymore, we have to disable the build cache to ensure we always use the latest version.

Building outside the directory where the dockerfile is, was also broken.