### PR TITLE
rename postgres backend compatibility to system table ompatibility

### DIFF
--- a/content/compatibility/_index.md
+++ b/content/compatibility/_index.md
@@ -6,35 +6,49 @@ weight: 90
 ---
 
 CedarDB is compatible with the PostgreSQL wire protocol version 3.0 and large parts of the PostgreSQL SQL dialect.
-In addition, CedarDB strives for full PostgreSQL compatibility wherever possible and reasonable, which often allows you to switch your applications and tools from PostgreSQL to CedarDB without any changes to your code.
-However, since CedarDB does not share a codebase with PostgreSQL, not all PostgreSQL features can be implemented in CedarDB in a meaningful way.
+In addition, CedarDB strives for full PostgreSQL compatibility wherever possible and reasonable, which often allows you
+to switch your applications and tools from PostgreSQL to CedarDB without any changes to your code.
+However, since CedarDB does not share a codebase with PostgreSQL, not all PostgreSQL features can be implemented in
+CedarDB in a meaningful way.
 
-This section provides an overview of PostgreSQL features that are already supported and known differences between CedarDB and PostgreSQL.
-
+This section provides an overview of PostgreSQL features that are already supported and known differences between
+CedarDB and PostgreSQL.
 
 ## Core SQL
-CedarDB already supports the vast majority of the PostgreSQL syntax, with more to come over time. You can find a list of supported statements, types and functions in our [Core SQL Compatibility](sql_features) documentation.
+
+CedarDB already supports the vast majority of the PostgreSQL syntax, with more to come over time. You can find a list of
+supported statements, types and functions in our [Core SQL Compatibility](sql_features) documentation.
 
 ## Ecosystem and Clients
 
-CedarDB is already fully wire protocol compatible with PostgreSQL. We are currently testing and adding support for all relevant programming language integrations and front-end applications.
-For an overview of those we have already validated, see the [Ecosystem and Client Compatibility](ecosystem_and_clients) page.
+CedarDB is already fully wire protocol compatible with PostgreSQL. We are currently testing and adding support for all
+relevant programming language integrations and front-end applications.
+For an overview of those we have already validated, see the [Ecosystem and Client Compatibility](ecosystem_and_clients)
+page.
 
 If you think an important client you depend on is missing, do not hesitate to contact us!
 
-## Backend
+## System Tables
 
-To ensure client compatibility, CedarDB is also compatible with a large number of PostgreSQL system tables, views and functions. While these are probably not relevant to most users of either CedarDB or PostgreSQL, tools and tool developers rely heavily on this functionality. For more details, see the [backend compatibility](backend) page.
+To ensure client compatibility, CedarDB is also compatible with a large number of PostgreSQL system tables, views and
+functions. While these are probably not relevant to most users of either CedarDB or PostgreSQL, tools and tool
+developers rely heavily on this functionality. For more details, see the [system table compatibility](system_table)
+page.
 
 ## Unsupported features
-PostgreSQL has accumulated a lot of features over its decades of development, and we do not consider all of them relevant to CedarDB.
+
+PostgreSQL has accumulated a lot of features over its decades of development, and we do not consider all of them
+relevant to CedarDB.
 Therefore, CedarDB will not be compatible with PostgreSQL in the following functionality.
 
 ### Unsupported types
+
 PostgreSQL provides extensive functionality for XML data types that we do not plan to support in CedarDB.
-While we plan to support geometric and geospatial types, as well as text search functionality, the implementation will likely differ from PostgreSQL's types and interfaces.
+While we plan to support geometric and geospatial types, as well as text search functionality, the implementation will
+likely differ from PostgreSQL's types and interfaces.
 
 ### PostgreSQL Extensions
+
 CedarDB is built from the ground up independent of PostgreSQL.
 Since extensions rely heavily on the internal structure of PostgreSQL, CedarDB is not compatible with them.
 However, we are integrating functionality from the most popular extensions into CedarDB.

--- a/content/compatibility/ecosystem_and_clients.md
+++ b/content/compatibility/ecosystem_and_clients.md
@@ -3,27 +3,34 @@ title: Ecosystem and Client Compatibility
 weight: 92
 ---
 
-CedarDB is compatible with the PostgreSQL protocol version 3 and aims to support many PostgreSQL-compatible tools and connectors out of the box.
-Since CedarDB does not share a codebase with PostgreSQL and we are still in the process of achieving full [backend compatibility](../backend), not all functionality will work out of the box.
-This page contains a list of clients, libraries, and other ecosystem components that we have verified to work with CedarDB. This list is by no means exhaustive, and many other tools should work as well.
+CedarDB is compatible with the PostgreSQL protocol version 3 and aims to support many PostgreSQL-compatible tools and
+connectors out of the box.
+Since CedarDB does not share a codebase with PostgreSQL, and we are still in the process of achieving
+full [system table compatibility](../system_table), not all functionality will work out of the box.
+This page contains a list of clients, libraries, and other ecosystem components that we have verified to work with
+CedarDB.
+This list is by no means exhaustive, and many other tools should work as well.
 
 {{< callout type="info" >}}
-If you come across something you feel is missing from the list, feel free to drop us a line on [Slack](https://bonsai.cedardb.com/slack) or [add it to the docs](https://github.com/cedardb/docs) directly.
+If you come across something you feel is missing from the list, feel free to drop us a line
+on [Slack](https://bonsai.cedardb.com/slack) or [add it to the docs](https://github.com/cedardb/docs) directly.
 {{< /callout >}}
 
-
 ## Supported Clients and Libraries
-Through both [SQL dialect](../sql_features) and [backend](../backend) compatibility, CedarDB works with a wide range of PostgreSQL connectors for end-user tools like Graphana and programming language drivers like JDBC.
 
+Through both [SQL dialect](../sql_features) and [system table](../system_table) compatibility, CedarDB works with a wide
+range of PostgreSQL connectors for end-user tools like Grafana and programming language drivers like JDBC.
 
 ### Applications
+
 | **Application** | **Version** | **Support State** | **Details**                              |
 |-----------------|-------------|-------------------|------------------------------------------|
-| DataGrip        | 2024.2.2    | Partial           | [Documentation](/docs/clients/datagrip/)  |
-| DBeaver         | 24.2.2      | Partial           | [Documentation](/docs/clients/dbeaver/) |
+| DataGrip        | 2024.2.2    | Partial           | [Documentation](/docs/clients/datagrip/) |
+| DBeaver         | 24.2.2      | Partial           | [Documentation](/docs/clients/dbeaver/)  |
 | Grafana         | 10.4.2      | Partial           | [Documentation](/docs/clients/grafana/)  |
 
 ### Programming Language Libraries
+
 | **Language** | **Framework**  | **Version** | **Support State** | **Details**                            |
 |--------------|----------------|-------------|-------------------|----------------------------------------|
 | C#           | Npgsql         | 8.0.4       | Full              | [Documentation](/docs/clients/csharp/) |
@@ -36,9 +43,15 @@ Through both [SQL dialect](../sql_features) and [backend](../backend) compatibil
 | Rust         | tokio-postgres | 0.7.12      | Full              | [Documentation](/docs/clients/rust/)   |
 
 ## Extensions
-Because extensions rely heavily on the internal structure of PostgreSQL, and because CedarDB does not share a codebase with PostgreSQL, CedarDB is generally not compatible with PostgreSQL extensions.
-However, since the functionality provided by extensions complements use cases not covered by raw SQL, we plan to integrate the functionality of the most popular extensions into CedarDB with language and interface compatibility.
+
+Because extensions rely heavily on the internal structure of PostgreSQL, and because CedarDB does not share a codebase
+with PostgreSQL, CedarDB is generally not compatible with PostgreSQL extensions.
+However, since the functionality provided by extensions complements use cases not covered by raw SQL, we plan to
+integrate the functionality of the most popular extensions into CedarDB with language and interface compatibility.
 
 ### pgvector
-CedarDB supports vector similarity search with the same interface and behavior as the PosgreSQL extension [pgvector](https://github.com/pgvector/pgvector).
-A more detailed description can be found in our [vector functionality documentation](/docs/references/advanced/pgvector/).
+
+CedarDB supports vector similarity search with the same interface and behavior as the PosgreSQL
+extension [pgvector](https://github.com/pgvector/pgvector).
+A more detailed description can be found in
+our [vector functionality documentation](/docs/references/advanced/pgvector/).

--- a/content/compatibility/sql_features.md
+++ b/content/compatibility/sql_features.md
@@ -3,15 +3,21 @@ title: Core SQL Compatibility
 prev: /compatibility
 weight: 91
 ---
-CedarDB implements the SQL dialect of PostgreSQL. While we are able to syntactically parse any PostgreSQL-compliant statement, not all underlying functionality is implemented yet.
+
+CedarDB implements the SQL dialect of PostgreSQL.
+While we are able to syntactically parse any PostgreSQL-compliant statement, not all underlying functionality is
+implemented yet.
 
 This page gives a **non-exhaustive** overview of currently supported core SQL functionality.
 CedarDB strives for full PostgreSQL compatibility, and features not currently supported will be added over time.
 
-For PostgreSQL-specific functionality, such as system table support, see the [backend compatibility](../backend) page.
+For PostgreSQL-specific functionality, such as system table support, see
+the [system table compatibility](../system-table) page.
 
 ## Data Definition
+
 ### Table Creation & Deletion
+
 | **Feature**           | **Support State** | **Details**                                                                                 |
 |-----------------------|-------------------|---------------------------------------------------------------------------------------------|
 | CREATE TABLE          | Yes               | [Documentation](/docs/references/sqlreference/statements/createtable/)                      |
@@ -28,6 +34,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | System Columns        | Yes               | Only meaningful for tableoid and ctid                                                       |
 
 ### Table Modification (ALTER TABLE)
+
 | **Feature**     | **Support State** | **Details** |
 |-----------------|-------------------|-------------|
 | ADD COLUMN      | Yes               |             |
@@ -44,6 +51,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | RENAME TO       | Yes               |             |
 
 ### Privileges
+
 | **Feature**           | **Support State** | **Details**                                                           |
 |-----------------------|-------------------|-----------------------------------------------------------------------|
 | CREATE ROLE           | Yes               | [Documentation](/docs/references/sqlreference/statements/createrole)  |
@@ -55,8 +63,8 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | INHERIT               | Yes               | [Documentation](/docs/references/sqlreference/statements/createrole/) |
 | Row Security Policies | No                |                                                                       |
 
-
 ### Indexes
+
 | **Feature**            | **Support State** | **Details**                                                                                |
 |------------------------|-------------------|--------------------------------------------------------------------------------------------|
 | CREATE INDEX           | Yes               | Only B-Tree Indexes [Documentation](/docs/references/sqlreference/statements/createindex/) |
@@ -69,6 +77,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | Partial Indexes        | No                |                                                                                            |
 
 ### Misc
+
 | **Feature**            | **Support State** | **Details**                                                                                                  |
 |------------------------|-------------------|--------------------------------------------------------------------------------------------------------------|
 | CREATE SCHEMA          | Yes               | [Documentation](/docs/references/sqlreference/statements/createschema/)                                      |
@@ -85,6 +94,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | Prepared Statements    | Yes               |                                                                                                              |
 
 ## Data Manipulation
+
 | **Feature** | **Support State** | **Details**                                                                 |
 |-------------|-------------------|-----------------------------------------------------------------------------|
 | INSERT      | Yes               | [Documentation](/docs/references/sqlreference/statements/insert/)           |
@@ -97,6 +107,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | ON CONFLICT | Yes               | [Documentation](/docs/references/sqlreference/statements/upsert/)           |
 
 ## Queries
+
 | **Feature**               | **Support State** | **Details**                                                                      |
 |---------------------------|-------------------|----------------------------------------------------------------------------------|
 | Table & View References   | Yes               |                                                                                  |
@@ -124,61 +135,61 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | OFFSET                    | Yes               |                                                                                  |
 | Table Generating Function | Yes               |                                                                                  |
 
-
 ## Data Types
 
 ### Types
 
 | **Feature**                             | **Support State** |                                                     **Details** |
 |-----------------------------------------|-------------------|----------------------------------------------------------------:|
-| array                                   | Yes               | [Array Documentation](/docs/references/datatypes/array)         |
-| bigint                                  | Yes               | [Integer Documentation](/docs/references/datatypes/integer)     |
+| array                                   | Yes               |         [Array Documentation](/docs/references/datatypes/array) |
+| bigint                                  | Yes               |     [Integer Documentation](/docs/references/datatypes/integer) |
 | bigserial                               | Yes               |                                                                 |
-| bit [ (n) ]                             | Yes               | [Bit Documentation](/docs/references/datatypes/bit)             |
-| bit varying [ (n) ]                     | Yes               | [Bit Documentation](/docs/references/datatypes/bit)             |
-| boolean                                 | Yes               | [Boolean Documentation](/docs/references/datatypes/boolean)     |
+| bit [ (n) ]                             | Yes               |             [Bit Documentation](/docs/references/datatypes/bit) |
+| bit varying [ (n) ]                     | Yes               |             [Bit Documentation](/docs/references/datatypes/bit) |
+| boolean                                 | Yes               |     [Boolean Documentation](/docs/references/datatypes/boolean) |
 | box                                     | No                |                                                                 |
-| bytea                                   | Yes               | [Blob Documentation](/docs/references/datatypes/blob)           |
-| character [ (n) ]                       | Yes               | [Text Documentation](/docs/references/datatypes/text)           |
-| character varying [ (n) ]               | Yes               | [Text Documentation](/docs/references/datatypes/text)           |
+| bytea                                   | Yes               |           [Blob Documentation](/docs/references/datatypes/blob) |
+| character [ (n) ]                       | Yes               |           [Text Documentation](/docs/references/datatypes/text) |
+| character varying [ (n) ]               | Yes               |           [Text Documentation](/docs/references/datatypes/text) |
 | cidr                                    | No                |                                                                 |
 | circle                                  | No                |                                                                 |
-| date                                    | Yes               | [Date Documentation](/docs/references/datatypes/date)           |
-| double precision                        | Yes               | [Double Documentation](/docs/references/datatypes/double)       |
+| date                                    | Yes               |           [Date Documentation](/docs/references/datatypes/date) |
+| double precision                        | Yes               |       [Double Documentation](/docs/references/datatypes/double) |
 | inet                                    | No                |                                                                 |
-| integer                                 | Yes               | [Integer Documentation](/docs/references/datatypes/integer)     |
-| interval [ fields ] [ (p) ]             | Yes               | [Interval Documentation](/docs/references/datatypes/interval)   |
-| json                                    | Yes               | [JSON Documentation](/docs/references/datatypes/json)           |
-| jsonb                                   | Yes               | [JSON Documentation](/docs/references/datatypes/json)           |
+| integer                                 | Yes               |     [Integer Documentation](/docs/references/datatypes/integer) |
+| interval [ fields ] [ (p) ]             | Yes               |   [Interval Documentation](/docs/references/datatypes/interval) |
+| json                                    | Yes               |           [JSON Documentation](/docs/references/datatypes/json) |
+| jsonb                                   | Yes               |           [JSON Documentation](/docs/references/datatypes/json) |
 | line                                    | No                |                                                                 |
 | lseg                                    | No                |                                                                 |
 | macaddr                                 | No                |                                                                 |
 | macaddr8                                | No                |                                                                 |
 | money                                   | No                |                                                                 |
-| numeric [ (p, s) ]                      | Yes               | [Numeric Documentation](/docs/references/datatypes/numeric)     |
+| numeric [ (p, s) ]                      | Yes               |     [Numeric Documentation](/docs/references/datatypes/numeric) |
 | path                                    | No                |                                                                 |
 | pg_lsn                                  | No                |                                                                 |
 | pg_snapshot                             | No                |                                                                 |
 | point                                   | No                |                                                                 |
 | polygon                                 | No                |                                                                 |
-| real                                    | Yes               | [Double Documentation](/docs/references/datatypes/double)       |
-| smallint                                | Yes               | [Integer Documentation](/docs/references/datatypes/integer)     |
+| real                                    | Yes               |       [Double Documentation](/docs/references/datatypes/double) |
+| smallint                                | Yes               |     [Integer Documentation](/docs/references/datatypes/integer) |
 | smallserial                             | Yes               |                                                                 |
 | serial                                  | Yes               |                                                                 |
-| text                                    | Yes               | [Text Documentation](/docs/references/datatypes/text)           |
-| time [ (p) ] [ without time zone ]      | Yes               | [Time Documentation](/docs/references/datatypes/time)           |
-| time [ (p) ] with time zone             | Yes               | [Time Documentation](/docs/references/datatypes/time)           |
+| text                                    | Yes               |           [Text Documentation](/docs/references/datatypes/text) |
+| time [ (p) ] [ without time zone ]      | Yes               |           [Time Documentation](/docs/references/datatypes/time) |
+| time [ (p) ] with time zone             | Yes               |           [Time Documentation](/docs/references/datatypes/time) |
 | timestamp [ (p) ] [ without time zone ] | Yes               | [Timestamp Documentation](/docs/references/datatypes/timestamp) |
 | timestamp [ (p) ] with time zone        | Yes               | [Timestamp Documentation](/docs/references/datatypes/timestamp) |
 | tsquery                                 | No                |                                                                 |
 | tsvector                                | No                |                                                                 |
 | txid_snapshot                           | No                |                                                                 |
-| uuid                                    | Yes               | [UUID Documentation](/docs/references/datatypes/uuid)           |
+| uuid                                    | Yes               |           [UUID Documentation](/docs/references/datatypes/uuid) |
 | xml                                     | No                |                                                                 |
 
 ### Operators & Functions
 
 #### Logical
+
 | **Feature** | **Support State** | **Details** |
 |-------------|-------------------|-------------|
 | AND         | Yes               |             |
@@ -186,6 +197,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | NOT         | Yes               |             |
 
 #### Comparison
+
 | **Feature**     | **Support State** | **Details** |
 |-----------------|-------------------|-------------|
 | <               | Yes               |             |
@@ -209,77 +221,79 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | IS NOT UNKNOWN  | Yes               |             |
 
 #### Mathematical
-| **Feature**   | **Support State** |              **Details** |
-|---------------|-------------------|-------------------------:|
-| +             | Yes               |                          |
-| -             | Yes               |                          |
-| *             | Yes               |                          |
-| /             | Yes               |                          |
-| %             | Yes               |                          |
-| ^             | Yes               |                          |
-| \|/           | Yes               |                          |
-| \|\|/         | Yes               |                          |
-| @             | Yes               |                          |
-| &             | Yes               |                          |
-| \|            | Yes               |                          |
-| #             | Yes               |                          |
-| ~             | Yes               |                          |
-| \<\<          | Yes               |                          |
-| \>\>          | Yes               |                          |
-| abs           | Yes               |                          |
-| cbrt          | Yes               |                          |
-| ceil          | Yes               |                          |
-| degrees       | Yes               |                          |
-| div           | Yes               |                          |
-| erf           | No                |                          |
-| erfc          | No                |                          |
-| exp           | Yes               |                          |
-| factorial     | Yes               | Also exists as ! operand |
-| floor         | Yes               |                          |
-| gcd           | No                |                          |
-| lcm           | No                |                          |
-| ln            | Yes               |                          |
-| log           | Yes               |                          |
-| log10         | Yes               |                          |
-| min_scale     | No                |                          |
-| mod           | Yes               |                          |
-| pi            | Yes               |                          |
-| power         | Yes               |                          |
-| radians       | Yes               |                          |
-| round         | Yes               |                          |
-| scale         | No                |                          |
-| sign          | Yes               |                          |
-| sqrt          | Yes               |                          |
-| trim_scale    | No                |                          |
-| trunc         | Yes               |                          |
-| width_bucket  | Yes               |                          |
-| random        | Yes               |                          |
-| random_normal | No                |                          |
-| setseed       | No                |                          |
-| acos          | Yes               |                          |
-| acosd         | Yes               |                          |
-| asin          | Yes               |                          |
-| asind         | Yes               |                          |
-| atan          | Yes               |                          |
-| atand         | Yes               |                          |
-| atan2         | Yes               |                          |
-| atan2d        | Yes               |                          |
-| cos           | Yes               |                          |
-| cosd          | Yes               | Because of rounding errors, cosd is not exactly 0 for its zero points. |
-| cot           | Yes               |                          |
+
+| **Feature**   | **Support State** |                                                                       **Details** |
+|---------------|-------------------|----------------------------------------------------------------------------------:|
+| +             | Yes               |                                                                                   |
+| -             | Yes               |                                                                                   |
+| *             | Yes               |                                                                                   |
+| /             | Yes               |                                                                                   |
+| %             | Yes               |                                                                                   |
+| ^             | Yes               |                                                                                   |
+| \|/           | Yes               |                                                                                   |
+| \|\|/         | Yes               |                                                                                   |
+| @             | Yes               |                                                                                   |
+| &             | Yes               |                                                                                   |
+| \|            | Yes               |                                                                                   |
+| #             | Yes               |                                                                                   |
+| ~             | Yes               |                                                                                   |
+| \<\<          | Yes               |                                                                                   |
+| \>\>          | Yes               |                                                                                   |
+| abs           | Yes               |                                                                                   |
+| cbrt          | Yes               |                                                                                   |
+| ceil          | Yes               |                                                                                   |
+| degrees       | Yes               |                                                                                   |
+| div           | Yes               |                                                                                   |
+| erf           | No                |                                                                                   |
+| erfc          | No                |                                                                                   |
+| exp           | Yes               |                                                                                   |
+| factorial     | Yes               |                                                          Also exists as ! operand |
+| floor         | Yes               |                                                                                   |
+| gcd           | No                |                                                                                   |
+| lcm           | No                |                                                                                   |
+| ln            | Yes               |                                                                                   |
+| log           | Yes               |                                                                                   |
+| log10         | Yes               |                                                                                   |
+| min_scale     | No                |                                                                                   |
+| mod           | Yes               |                                                                                   |
+| pi            | Yes               |                                                                                   |
+| power         | Yes               |                                                                                   |
+| radians       | Yes               |                                                                                   |
+| round         | Yes               |                                                                                   |
+| scale         | No                |                                                                                   |
+| sign          | Yes               |                                                                                   |
+| sqrt          | Yes               |                                                                                   |
+| trim_scale    | No                |                                                                                   |
+| trunc         | Yes               |                                                                                   |
+| width_bucket  | Yes               |                                                                                   |
+| random        | Yes               |                                                                                   |
+| random_normal | No                |                                                                                   |
+| setseed       | No                |                                                                                   |
+| acos          | Yes               |                                                                                   |
+| acosd         | Yes               |                                                                                   |
+| asin          | Yes               |                                                                                   |
+| asind         | Yes               |                                                                                   |
+| atan          | Yes               |                                                                                   |
+| atand         | Yes               |                                                                                   |
+| atan2         | Yes               |                                                                                   |
+| atan2d        | Yes               |                                                                                   |
+| cos           | Yes               |                                                                                   |
+| cosd          | Yes               |            Because of rounding errors, cosd is not exactly 0 for its zero points. |
+| cot           | Yes               |                                                                                   |
 | cotd          | Yes               | For the values where cotd is undefined, the value of the C++ library is returned. |
-| sin           | Yes               |                          |
-| sind          | Yes               | Because of rounding errors, cosd is not exactly 0 for its zero points. |
-| tan           | Yes               |                          |
+| sin           | Yes               |                                                                                   |
+| sind          | Yes               |            Because of rounding errors, cosd is not exactly 0 for its zero points. |
+| tan           | Yes               |                                                                                   |
 | tand          | Yes               | For the values where tand is undefined, the value of the C++ library is returned. |
-| sinh          | Yes               |                          |
-| cosh          | Yes               |                          |
-| tanh          | Yes               |                          |
-| asinh         | Yes               |                          |
-| acosh         | Yes               |                          |
-| atanh         | Yes               |                          |
+| sinh          | Yes               |                                                                                   |
+| cosh          | Yes               |                                                                                   |
+| tanh          | Yes               |                                                                                   |
+| asinh         | Yes               |                                                                                   |
+| acosh         | Yes               |                                                                                   |
+| atanh         | Yes               |                                                                                   |
 
 #### String
+
 | **Feature**           | **Support State** |                                           **Details** |
 |-----------------------|-------------------|------------------------------------------------------:|
 | \|\|                  | Yes               |                                                       |
@@ -317,7 +331,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | regexp_like           | No                |                                                       |
 | regexp_match          | Yes               |                                                       |
 | regexp_matches        | Yes               |                                                       |
-| regexp_replace        | Yes               | Currently not supporting replacing N'th match         |
+| regexp_replace        | Yes               |         Currently not supporting replacing N'th match |
 | regexp_split_to_array | Yes               |                                                       |
 | regexp_split_to_table | Yes               |                                                       |
 | regexp_substr         | Yes               |                                                       |
@@ -337,6 +351,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | unistr                | No                |                                                       |
 
 #### Bytea
+
 | **Feature**  | **Support State** |             **Details** |
 |--------------|-------------------|------------------------:|
 | \|\|         | Yes               |                         |
@@ -360,13 +375,14 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | sha384       | No                |                         |
 | sha512       | No                |                         |
 | substr       | Yes               |                         |
-| convert      | Yes               | Only for UTF8           |
-| convert_from | Yes               | Only for UTF8           |
-| convert_to   | Yes               | Only for UTF8           |
+| convert      | Yes               |           Only for UTF8 |
+| convert_from | Yes               |           Only for UTF8 |
+| convert_to   | Yes               |           Only for UTF8 |
 | encode       | Yes               |                         |
 | decode       | Yes               |                         |
 
 #### Bit
+
 | **Feature**  | **Support State** | **Details** |
 |--------------|-------------------|------------:|
 | \|\|         | No                |             |
@@ -387,12 +403,14 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | set_bit      | Yes               |             |
 
 #### Pattern Matching
+
 | **Feature** | **Support State** | **Details** |
 |-------------|-------------------|-------------|
 | LIKE        | Yes               |             |
 | SIMILAR TO  | Yes               |             |
 
 #### Data Type Formatting
+
 | **Feature**  | **Support State** | **Details** |
 |--------------|-------------------|-------------|
 | to_char      | No                |             |
@@ -401,6 +419,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | to_timestamp | No                |             |
 
 #### Date/Time
+
 | **Feature**           | **Support State** | **Details**      |
 |-----------------------|-------------------|------------------|
 | +                     | Yes               |                  |
@@ -438,14 +457,15 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | EXTRACT               | Yes               | Without timezone |
 
 #### Enum
+
 | **Feature** | **Support State** | **Details** |
 |-------------|-------------------|-------------|
 | enum_first  | No                |             |
 | enum_last   | No                |             |
 | enum_range  | No                |             |
 
-
 #### Geometric
+
 | **Feature**  | **Support State** | **Details** |
 |--------------|-------------------|-------------|
 | +            | No                |             |
@@ -500,6 +520,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | polygon      | No                |             |
 
 #### Network
+
 | **Feature**      | **Support State** | **Details** |
 |------------------|-------------------|-------------|
 | \<\<             | No                |             |
@@ -526,6 +547,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | text             | No                |             |
 
 #### Text Search
+
 | **Feature**           | **Support State** | **Details** |
 |-----------------------|-------------------|-------------|
 | @@                    | No                |             |
@@ -564,6 +586,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | ts_stat               | No                |             |
 
 #### UUID
+
 | **Feature**            | **Support State** | **Details** |
 |------------------------|-------------------|-------------|
 | get_random_uuid        | Yes               |             |
@@ -571,6 +594,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | uuid_extract_version   | No                |             |
 
 #### XML
+
 | **Feature**        | **Support State** | **Details** |
 |--------------------|-------------------|-------------|
 | xmltext            | No                |             |
@@ -590,6 +614,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | XMLTABLE           | No                |             |
 
 #### JSON
+
 | **Feature**               | **Support State** | **Details** |
 |---------------------------|-------------------|-------------|
 | ->                        | Yes               |             |
@@ -646,6 +671,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | json_path                 | No                |             |
 
 #### Sequence Manipulation
+
 | **Feature** | **Support State** | **Details** |
 |-------------|-------------------|-------------|
 | nextval     | Yes               |             |
@@ -654,6 +680,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | lastval     | No                |             |
 
 #### Conditional
+
 | **Feature** | **Support State** | **Details** |
 |-------------|-------------------|-------------|
 | CASE        | Yes               |             |
@@ -663,6 +690,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | LEAST       | Yes               |             |
 
 #### Array
+
 | **Feature**       | **Support State** | **Details**              |
 |-------------------|-------------------|--------------------------|
 | @>                | Yes               |                          |
@@ -689,6 +717,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | unnest            | Yes               | No multi-array expansion |
 
 #### Range
+
 | **Feature** | **Support State** | **Details** |
 |-------------|-------------------|-------------|
 | @>          | No                |             |
@@ -716,6 +745,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 #### Aggregate Functions
 
 ##### Generic
+
 | **Feature**           | **Support State** |                                                                                                        **Details** |
 |-----------------------|-------------------|-------------------------------------------------------------------------------------------------------------------:|
 | any_value             | Yes               | [Aggregate Function Documentation](/docs/references/sqlreference/functions/aggregation/#general-purpose-functions) |
@@ -740,6 +770,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | xmlagg                | No                |                                                                                                                    |
 
 ##### Statistical
+
 | **Feature**    | **Support State** |                                                                                                     **Details** |
 |----------------|-------------------|----------------------------------------------------------------------------------------------------------------:|
 | corr           | No                |                                                                                                                 |
@@ -762,6 +793,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | var_samp       | Yes               | [Aggregate Function Documentation](/docs/references/sqlreference/functions/aggregation/#statistical-aggregates) |
 
 ##### Ordered-Set
+
 | **Feature**     | **Support State** |                                                                                                               **Details** |
 |-----------------|-------------------|--------------------------------------------------------------------------------------------------------------------------:|
 | mode            | Yes               | [Aggregate Function Documentation](/docs/references/sqlreference/functions/aggregation//#ordered-set-aggregate-functions) |
@@ -769,6 +801,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | percentile_disc | Yes               | [Aggregate Function Documentation](/docs/references/sqlreference/functions/aggregation//#ordered-set-aggregate-functions) |
 
 #### Window
+
 | **Feature**  | **Support State** | **Details** |
 |--------------|-------------------|-------------|
 | row_number   | Yes               |             |
@@ -784,6 +817,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | nth_value    | Yes               |             |
 
 #### Subquery
+
 | **Feature** | **Support State** | **Details** |
 |-------------|-------------------|-------------|
 | EXISTS      | Yes               |             |
@@ -793,6 +827,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | ALL         | Yes               |             |
 
 #### Array Comparison
+
 | **Feature** | **Support State** | **Details** |
 |-------------|-------------------|-------------|
 | EXISTS      | Yes               |             |
@@ -802,6 +837,7 @@ For PostgreSQL-specific functionality, such as system table support, see the [ba
 | ALL         | Yes               |             |
 
 #### Set Returning
+
 | **Feature**        | **Support State** | **Details** |
 |--------------------|-------------------|-------------|
 | generate_series    | Yes               |             |

--- a/content/compatibility/system_table.md
+++ b/content/compatibility/system_table.md
@@ -1,12 +1,15 @@
 ---
-title: Backend Compatibility
+title: System Table Compatibility
 next: /roadmap
 weight: 93
 ---
 
 Besides compatibility with the PostgreSQL [SQL dialect and protocol](../sql_features), CedarDB also supports a large
-part of the PostgreSQL backend system catalog, which is often used by external tools and clients to interact with the
-database system.
+part of the PostgreSQL system table catalog in the `pg_catalog` schema.
+These system tables contain information about the *system* state in the form of metadata.
+This metadata is often used by external tools and clients to interact with the database system for introspection and
+reflection, e.g., to show which tables exist.
+
 This page provides an overview of the currently supported system tables and views.
 
 - 🟢 **Fully supported features.**
@@ -15,6 +18,14 @@ This page provides an overview of the currently supported system tables and view
 - 🔴 **Catalog entries without meaningful content.**
 
 ## System Tables
+
+System tables provide a raw view into the state of the database system.
+In contrast to PostgreSQL, system tables in CedarDB are *read-only*, and can only be indirectly influenced through
+[DDL statements](/docs/references/sqlreference/statements/).
+
+System tables often contain many low-level details.
+For more accessible and friendly access to the same information, consider using the
+built-in [system views](#system-views), or the SQL-standard [information schema](#information-schema).
 
 | Feature                                                                                                   | Support State | Details                                                                                   |
 |-----------------------------------------------------------------------------------------------------------|---------------|-------------------------------------------------------------------------------------------|
@@ -85,6 +96,10 @@ This page provides an overview of the currently supported system tables and view
 
 ## System Views
 
+System views provide convenient access to system information.
+System tables often contain numeric identifiers, e.g., for the owner of tables.
+The views instead use more human-readable symbolic names.
+
 | Feature                                                                                                              | Support State | Details                                                                                                                 |
 |----------------------------------------------------------------------------------------------------------------------|---------------|-------------------------------------------------------------------------------------------------------------------------|
 | [pg_available_extensions](https://www.postgresql.org/docs/current/view-pg-available-extensions.html)                 | 🟡            | Lists available extensions.                                                                                             |
@@ -128,12 +143,15 @@ For compatibility, CedarDB follows
 the [PostgreSQL Information Schema](https://www.postgresql.org/docs/current/information-schema.html),
 which matches the [ISO/IEC 9075-11](https://www.iso.org/standard/76586.html) standard.
 
+{{< callout type="info" >}}
 The information schema views are *not* included in the default search path, so queries on it need to use the
 fully qualified name:
 
 ```sql
 select * from information_schema.tables;
 ```
+
+{{< /callout >}}
 
 | Table name                            | Support State | Details                                                                            |
 |---------------------------------------|---------------|------------------------------------------------------------------------------------|

--- a/content/roadmap.md
+++ b/content/roadmap.md
@@ -5,64 +5,75 @@ prev: /compatibility
 weight: 100
 ---
 
-This page provides a brief overview of the most important CedarDB [database](#database-features) and [enterprise](#enterprise-features) features that are next on our roadmap. Information about intermediate status of features and minor features will be available in our release notes.
+This page provides a brief overview of the most important CedarDB [database](#database-features)
+and [enterprise](#enterprise-features) features that are next on our roadmap.
+Information about intermediate status of features and minor features will be available in our release notes.
 
 We categorise the status of the features on this page as planned, in progress, and fully available:
 
 | **State**          |               **Icon** |
 |--------------------|-----------------------:|
-| Planned            |   {{< iconplanned >}}  |
+| Planned            |    {{< iconplanned >}} |
 | Under Construction | {{< iconinprogress >}} |
-| Available          |    {{< icondone >}}    |
+| Available          |       {{< icondone >}} |
 
-
-A more detailed overview of our PostgreSQL compatibility level can be found on the separate [Compatibility](../compatibility/) page.
+A more detailed overview of our PostgreSQL compatibility level can be found on the
+separate [Compatibility](../compatibility/) page.
 Features in progress are often already partially available in CedarDB.
 
-We plan to update this page regularly to accurately reflect our progress and changes in feature prioritisation.
+We plan to update this page regularly to accurately reflect our progress and changes in feature prioritization.
 
 {{< callout type="info" >}}
-If you feel that features that are important to you are missing from the list, feel free to drop us a line on [Slack](https://bonsai.cedardb.com/slack). We'd love to hear from you!
+If you feel that features that are important to you are missing from the list, feel free to drop us a line
+on [Slack](https://bonsai.cedardb.com/slack) or [open an issues](https://github.com/cedardb/issues).
+We'd love to hear from you!
 {{< /callout >}}
 
 ## Database Features
+
 {{< callout type="info" >}}
-This section contains information about planned core database features that we plan to make available to all users of CedarDB.
+This section contains information about planned core database features that we plan to make available to all users of
+CedarDB.
 {{< /callout >}}
 
-
 ### Data Model & Domain-Specific Features
+
 | **Feature**                  |              **State** | **Details**                                                |
 |------------------------------|-----------------------:|------------------------------------------------------------|
-| AsOf joins                   |    {{< icondone >}}    | [Documentation](/docs/references/advanced/asof_join/)      |
-| Fulltext search              |   {{< iconplanned >}}  |                                                            |
-| Enhanced graph query support |   {{< iconplanned >}}  |                                                            |
+| AsOf joins                   |       {{< icondone >}} | [Documentation](/docs/references/advanced/asof_join/)      |
+| Fulltext search              |    {{< iconplanned >}} |                                                            |
+| Enhanced graph query support |    {{< iconplanned >}} |                                                            |
 | Range types                  | {{< iconinprogress >}} |                                                            |
 | Schema evolution             | {{< iconinprogress >}} | [Documentation](/docs/references/sqlreference/statements/) |
 | Vector support               | {{< iconinprogress >}} | [Documentation](/docs/references/advanced/pgvector/)       |
 
 ### Data Formats
+
 | **Feature**           |              **State** | **Details**                                                |
 |-----------------------|-----------------------:|------------------------------------------------------------|
-| Parquet reader        |   {{< iconplanned >}}  |                                                            |
-| Parquet writer        |   {{< iconplanned >}}  |                                                            |
-| Iceberg support       |   {{< iconplanned >}}  |                                                            |
+| Parquet reader        |    {{< iconplanned >}} |                                                            |
+| Parquet writer        |    {{< iconplanned >}} |                                                            |
+| Iceberg support       |    {{< iconplanned >}} |                                                            |
 | pg_dump compatibility | {{< iconinprogress >}} | [Documentation](/docs/cookbook/importing_from_postgresql/) |
 
 ### Connectivity
-| **Feature**                    |              **State** | **Details**                                      |
-|--------------------------------|-----------------------:|--------------------------------------------------|
-| PostgreSQL system tables       |    {{< icondone >}}    | [Documentation](/docs/compatibility/backend/)    |
-| information_schema support     | {{< iconinprogress >}} | [Documentation](/docs/compatibility/backend/)    |
-| PostgreSQL Logical replication | {{< iconinprogress >}} |                                                  |
-| Support for more CDC tools     | {{< iconinprogress >}} | [Documentation](/docs/cookbook/aurora_debezium/) |
+
+| **Feature**                    |              **State** | **Details**                                        |
+|--------------------------------|-----------------------:|----------------------------------------------------|
+| PostgreSQL system tables       |       {{< icondone >}} | [Documentation](/docs/compatibility/system_table/) |
+| information_schema support     |       {{< icondone >}} | [Documentation](/docs/compatibility/system_table/) |
+| PostgreSQL Logical replication | {{< iconinprogress >}} |                                                    |
+| Support for more CDC tools     | {{< iconinprogress >}} | [Documentation](/docs/cookbook/aurora_debezium/)   |
 
 ## Enterprise Features
+
 {{< callout type="info" >}}
-This section contains features that are primarily intended for enterprise customers and are most relevant to large-scale production use of CedarDB. These features may not be available to all CedarDB users.
+This section contains features that are primarily intended for enterprise customers and are most relevant to large-scale
+production use of CedarDB. These features may not be available to all CedarDB users.
 {{< /callout >}}
 
 ### Operations
+
 | **Feature**                 |           **State** | **Details** |
 |-----------------------------|--------------------:|-------------|
 | Read replication to CedarDB | {{< iconplanned >}} |             |
@@ -73,8 +84,9 @@ This section contains features that are primarily intended for enterprise custom
 | Query progress tracking     | {{< iconplanned >}} |             |
 
 ### Multi Tenancy
+
 | **Feature**                            |              **State** | **Details** |
 |----------------------------------------|-----------------------:|-------------|
-| Resource limits for individual tenants |   {{< iconplanned >}}  |             |
+| Resource limits for individual tenants |    {{< iconplanned >}} |             |
 | Extended role & grant management       | {{< iconinprogress >}} |             |
-| Fair scheduling over multiple tenants  |   {{< iconplanned >}}  |             |
+| Fair scheduling over multiple tenants  |    {{< iconplanned >}} |             |


### PR DESCRIPTION
Rename the docs page from "Backend" to "System Table". Most DBMS call them system tables, so use that name to avoid confusion.