### PR TITLE
Fix legal stuff

### DIFF
--- a/content/community_edition.md
+++ b/content/community_edition.md
@@ -22,7 +22,7 @@ Looking for advanced features or enterprise support? Check out the **Enterprise 
 |                              | Community Edition                                                                     | Enterprise Edition        |
 |------------------------------|---------------------------------------------------------------------------------------|---------------------------|
 | <b>Maximum Data Set Size</b> | 64 GiB                                                                                | unlimited                 |
-| <b>Support</b>               | [Community Slack](https://bonsai.cedardb.com/slack)                                   | Per terms of your license |
+| <b>Commercial Support</b>    | [Contact Us](mailto:sales@cedardb.com) (consider joining our [Community Slack](https://bonsai.cedardb.com/slack))       | Per terms of your license |
 | <b>License</b>               | [Community Edition license](https://cedardb.com/legal/agreements/community_tcs.pdf)   | Paid enterprise license   |
 
 

--- a/content/get_started/install_locally.md
+++ b/content/get_started/install_locally.md
@@ -17,6 +17,10 @@ To automatically download and decompress the appropriate version, run:
 curl https://get.cedardb.com | bash
 ```
 
+{{< callout type="info" >}}
+By using CedarDB, you agree to our [Terms and Conditions]({{< relref "/licensing.md" >}}).
+{{< /callout >}}
+
 CedarDB supports two modes of operation:
 - **Interactive mode:** A SQL shell for direct, manual interaction with the database.
 - **Server mode:** A PostgreSQL-compatible server for external clients.

--- a/content/get_started/install_with_docker.md
+++ b/content/get_started/install_with_docker.md
@@ -13,6 +13,11 @@ Pull the official CedarDB image:
 ```shell
 docker pull cedardb/cedardb
 ```
+
+{{< callout type="info" >}}
+By using CedarDB, you agree to our [Terms and Conditions]({{< relref "/licensing.md" >}}).
+{{< /callout >}}
+
 Start a container:
 
 ```shell

--- a/content/get_started/operate_in_cloud.md
+++ b/content/get_started/operate_in_cloud.md
@@ -51,6 +51,10 @@ We recommend using the latest **Ubuntu LTS** release (i.e., Ubuntu 24.04 as of w
   {{< /tab >}}
 {{< /tabs >}}
 
+{{< callout type="info" >}}
+By using CedarDB, you agree to our [Terms and Conditions]({{< relref "/licensing.md" >}}).
+{{< /callout >}}
+
 ---
 
 ## Instance sizing guidelines

--- a/content/get_started/quickstart.md
+++ b/content/get_started/quickstart.md
@@ -16,6 +16,10 @@ To automatically download and decompress the appropriate CedarDB version, run:
 curl https://get.cedardb.com | bash
 ```
 
+{{< callout type="info" >}}
+By using CedarDB, you agree to our [Terms and Conditions]({{< relref "/licensing.md" >}}).
+{{< /callout >}}
+
 Then start an interactive SQL shell connected to a temporary database:
 
 ```shell


### PR DESCRIPTION
Our lawyers said that we need to reference our Terms and Conditions from every page where we reference a way to download CedarDB. Also, we should not imply that we guarantee support via Slack as otherwise even Community Edition users may force us to do so.