### PR TITLE
Add documentation for regexp_like()

### DIFF
--- a/content/compatibility/sql_features.md
+++ b/content/compatibility/sql_features.md
@@ -291,7 +291,7 @@ the [system table compatibility](../system-table) page.
 | acosh         | Yes               |                                                                                   |
 | atanh         | Yes               |                                                                                   |
 
-#### String
+#### Text
 
 | **Feature**           | **Support State** |                                           **Details** |
 |-----------------------|-------------------|------------------------------------------------------:|
@@ -325,15 +325,6 @@ the [system table compatibility](../system-table) page.
 | quote_ident           | Yes               |                                                       |
 | quote_literal         | Yes               |                                                       |
 | quote_nullable        | Yes               |                                                       |
-| regexp_count          | No                |                                                       |
-| regexp_instr          | No                |                                                       |
-| regexp_like           | No                |                                                       |
-| regexp_match          | Yes               |                                                       |
-| regexp_matches        | Yes               |                                                       |
-| regexp_replace        | Yes               |         Currently not supporting replacing N'th match |
-| regexp_split_to_array | Yes               |                                                       |
-| regexp_split_to_table | Yes               |                                                       |
-| regexp_substr         | Yes               |                                                       |
 | repeat                | Yes               |                                                       |
 | replace               | Yes               |                                                       |
 | reverse               | Yes               |                                                       |
@@ -403,10 +394,19 @@ the [system table compatibility](../system-table) page.
 
 #### Pattern Matching
 
-| **Feature** | **Support State** | **Details** |
-|-------------|-------------------|-------------|
-| LIKE        | Yes               |             |
-| SIMILAR TO  | Yes               |             |
+| **Feature**           | **Support State** |                                   **Details** |
+|-----------------------|-------------------|----------------------------------------------:|
+| LIKE                  | Yes               |                                               |
+| SIMILAR TO            | Yes               |                                               |
+| regexp_count          | No                |                                               |
+| regexp_instr          | No                |                                               |
+| regexp_like           | Yes               |                                               |
+| regexp_match          | Yes               |                                               |
+| regexp_matches        | Yes               |                                               |
+| regexp_replace        | Yes               | Currently not supporting replacing N'th match |
+| regexp_split_to_array | Yes               |                                               |
+| regexp_split_to_table | Yes               |                                               |
+| regexp_substr         | Yes               |                                               |
 
 #### Data Type Formatting
 

--- a/content/references/sqlreference/functions/_index.md
+++ b/content/references/sqlreference/functions/_index.md
@@ -18,7 +18,7 @@ Functions are usually type specific, but are often overloaded to work with diffe
   * Interval functions
   * [JSON functions](json)
   * Numeric functions
-  * Text functions
+  * [Text functions](./text)
   * Time functions
   * Timestamp functions
   * UUID functions

--- a/content/references/sqlreference/functions/text.md
+++ b/content/references/sqlreference/functions/text.md
@@ -1,0 +1,35 @@
+---
+title: "Reference: Text Functions"
+linkTitle: "Text"
+---
+
+CedarDB supports a variety of functions for the [text](/docs/references/datatypes/text) data type. This page currently
+only describes a  subset of those. See [SQL features](/docs/compatibility/sql_features) for a full list of supported
+functions.
+
+## Pattern Matching
+
+### POSIX Regular Expressions
+
+CedarDB allows to specify POSIX regular expressions within a pattern.
+The following functions allow to specify such a pattern.
+
+#### regexp_like()
+
+**Arguments**: (string, pattern [, flags ]))
+
+The `regexp_like()` function compares a pattern to a string. It returns true if the pattern matches the string and
+false if it does not. If any input is null, the output is also null. Flags change the function's semantics;
+for example, the `i` flag makes the pattern matching case-insensitive.
+
+```sql
+select regexp_like('The General Sherman tree is the largest tree in the world.', 'Tree.*Largest', 'i') as foo;
+```
+
+```
+ foo 
+-----
+ t
+(1 row)
+```
+


### PR DESCRIPTION
### Regexp_like()

1. Ticks the box within the supported sql features.
2. Renamed the `String` to the `Text` section in the sql features.
3. Moved the regexp functions to the `Pattern Matching `section.
4. Created a new page within `references/sqlreferences/functions `for text functions and added docs for the `regexp_like() `function.

