### PR TITLE
Add docs for string_to_table

### DIFF
--- a/content/compatibility/sql_features.md
+++ b/content/compatibility/sql_features.md
@@ -332,7 +332,7 @@ the [system table compatibility](../system-table) page.
 | split_part            | Yes               |                                                       |
 | starts_with           | Yes               |                                                       |
 | string_to_array       | Yes               |                                                       |
-| string_to_table       | No                |                                                       |
+| string_to_table       | Yes               |                                                       |
 | strpos                | Yes               |                                                       |
 | substr                | Yes               |                                                       |
 | to_ascii              | No                |                                                       |

--- a/content/references/sqlreference/functions/text.md
+++ b/content/references/sqlreference/functions/text.md
@@ -7,6 +7,38 @@ CedarDB supports a variety of functions for the [text](/docs/references/datatype
 only describes a  subset of those. See [SQL features](/docs/compatibility/sql_features) for a full list of supported
 functions.
 
+## Functions and Operators
+
+### string_to_table()
+
+**Arguments**: (_string_ text, _delimiter_ text [, _null_string_ text ]))
+
+The `string_to_table()` function splits a _string_ at the _delimiter_ and replaces output words that match the
+_null_string_ by null. If the _delimiter_ is NULL, the _string_ is split into all its characters. If the _delimiter_ is
+empty, the _string_ is not split at all.
+The final result is returned as a column of type **text** where each output word is a row.
+
+```sql
+select string_to_table('The General Sherman tree is the largest tree in the world.', ' ', 'the') as foo;
+```
+
+```
+ foo 
+-----
+The
+General
+Sherman
+tree
+is
+NULL
+largest
+tree
+in
+NULL
+world.
+(11 rows)
+```
+
 ## Pattern Matching
 
 ### POSIX Regular Expressions
@@ -16,10 +48,10 @@ The following functions allow to specify such a pattern.
 
 #### regexp_like()
 
-**Arguments**: (string, pattern [, flags ]))
+**Arguments**: (_string_ text, _pattern_ text [, _flags_ text]))
 
-The `regexp_like()` function compares a pattern to a string. It returns true if the pattern matches the string and
-false if it does not. If any input is null, the output is also null. Flags change the function's semantics;
+The `regexp_like()` function compares a _pattern_ to a _string_. It returns true if the _pattern_ matches the _string_
+and false if it does not. If any input is null, the output is also null. _Flags_ change the function's semantics;
 for example, the `i` flag makes the pattern matching case-insensitive.
 
 ```sql

--- a/content/references/sqlreference/functions/text.md
+++ b/content/references/sqlreference/functions/text.md
@@ -9,7 +9,7 @@ functions.
 
 ## Functions and Operators
 
-### string_to_table()
+#### string_to_table()
 
 **Arguments**: (_string_ text, _delimiter_ text [, _null_string_ text ]))
 


### PR DESCRIPTION
# Add docs for string_to_table

This PR add documentation for the string_to_table() function I implemented. (See https://github.com/cedardb/cedardb/pull/1508)