### PR TITLE
Sepcify benchmarking only for interactive mode and get rid of debug

### DIFF
--- a/content/get_started/install_locally.md
+++ b/content/get_started/install_locally.md
@@ -8,7 +8,7 @@ This tutorial explains how to install and run the native CedarDB binary on your 
 
 ## Get the binary
 
-CedarDB is distributed as a standalone binary. 
+CedarDB is distributed as a standalone binary.
 It runs out of the box on any Linux distribution with **glibc >= 2.27** (released in 2018).
 
 
@@ -22,84 +22,16 @@ By using CedarDB, you agree to our [Terms and Conditions]({{< relref "/licensing
 {{< /callout >}}
 
 CedarDB supports two modes of operation:
-- **Interactive mode:** A SQL shell for direct, manual interaction with the database.
 - **Server mode:** A PostgreSQL-compatible server for external clients.
-
-## Run interactively
-
-Interactive mode launches a REPL-style SQL shell.
-You can use it to create, explore, and manipulate a database locally.
-
-
-### Create a new persistent database
-To create and open a persistent database:
-```shell
-./cedardb --interactive --createdb mydb
-```
-
-This creates a new directory `mydb` in your current working directory where CedarDB stores its data files.
-
-You can also specify an absolute or relative path:
-
-```shell
-./cedardb --interactive --createdb /opt/dbs/movies
-```
-
-
-{{< callout type="info" >}}
-Ensure the database is stored on a reasonably fast SSD for optimal performance.
-{{< /callout >}}
-
-### Open an existing database
-
-If the database already exists, you can open it like this:
-```shell
-./cedardb --interactive mydb
-```
-
-{{< callout type="info" >}} 
-Using the `--createdb` flag will create the database if it doesn't exist.
-If the database already exists, it will open the database instead.
-
-Without the flag, CedarDB will only open an existing database and fail if none is found.
-{{< /callout >}}
-
-### Create a temporary in-memory database
-
-To launch an ephemeral, in-memory database:
-```shell
-./cedardb --interactive --inmemory
-```
-This database exists only for the duration of the session and will be discarded upon exit.
-
-{{< callout type="info" >}}
-Since this database is held completely in-memory, working with large data sets can quickly exhaust system memory and cause OOM.
-{{< /callout >}}
-
-### Running SQL in the shell
-
-Once in the SQL shell, you can run standard SQL:
-```sql
-create table example(i int);
-insert into example values (42);
-```
-The REPL supports:
-- Common readline keyboard shortcuts (e.g., CTRL + R to search the history)
-- Backslash commands:
-```sql
-\i schema_definition.sql -- Run commands from a file
-\?                       -- View available commands
-```
-
-For more details, see the [SQL Reference](/docs/references/sqlreference/).
+- **Interactive mode:** A SQL shell for direct, manual interaction with the database.
 
 ## Run as Server
 
-While interactive mode is great for development and testing, server mode is recommended for production use.
+The best way to set up CedarDB for production use is to start CedarDB in our PostgreSQL-compatible server mode.
 
 ### Start in Server mode
 
-By default (i.e., if you omit the `--interactive` flag), CedarDB runs in server mode:
+By default, CedarDB runs in server mode:
 
 ```shell
 ./cedardb --createdb mydb
@@ -144,3 +76,75 @@ To see all available flags and options, run:
 {{< callout type="info" >}}
 If you have obtained an enterprise license, refer to the [licensing page](../../licensing) for a step-by-step guide on how to activate it.
 {{< /callout >}}
+
+
+
+## Run interactively
+
+Interactive mode launches a REPL-style SQL shell.
+You can use it to create, explore, and manipulate a database locally.
+
+
+### Create a new persistent database
+To create and open a persistent database:
+```shell
+./cedardb --interactive --createdb mydb
+```
+
+This creates a new directory `mydb` in your current working directory where CedarDB stores its data files.
+
+You can also specify an absolute or relative path:
+
+```shell
+./cedardb --interactive --createdb /opt/dbs/movies
+```
+
+
+{{< callout type="info" >}}
+Ensure the database is stored on a reasonably fast SSD for optimal performance.
+{{< /callout >}}
+
+### Open an existing database
+
+If the database already exists, you can open it like this:
+```shell
+./cedardb --interactive mydb
+```
+
+{{< callout type="info" >}}
+Using the `--createdb` flag will create the database if it doesn't exist.
+If the database already exists, it will open the database instead.
+
+Without the flag, CedarDB will only open an existing database and fail if none is found.
+{{< /callout >}}
+
+### Create a temporary in-memory database
+
+To launch an ephemeral, in-memory database:
+```shell
+./cedardb --interactive --inmemory
+```
+This database exists only for the duration of the session and will be discarded upon exit.
+
+{{< callout type="info" >}}
+Since this database is held completely in-memory, working with large data sets can quickly exhaust system memory and cause OOM.
+{{< /callout >}}
+
+
+### Running SQL in the shell
+
+Once in the SQL shell, you can run standard SQL:
+```sql
+create table example(i int);
+insert into example values (42);
+```
+The REPL supports:
+- Common readline keyboard shortcuts (e.g., CTRL + R to search the history)
+- Backslash commands:
+```sql
+\i schema_definition.sql -- Run commands from a file
+\?                       -- View available commands
+```
+
+For more details, see the [SQL Reference](/docs/references/sqlreference/).
+

--- a/content/references/advanced/benchmarking.md
+++ b/content/references/advanced/benchmarking.md
@@ -1,0 +1,56 @@
+---
+title: Benchmarking in interactive mode
+linktitle: Interactive Benchmarking
+
+---
+
+For benchmarking purposes, we support several advanced settings in CedarDB's interactive mode.
+
+## Repetition of queries
+
+To validate performance, it is important to run queries multiple times.
+To repeat a query, you can either repeat the execution (`e`), the compilation (`c`), or both (`a`).
+To change the repetition mode, simply query this command.
+
+```
+\set repeatmode 'a'
+```
+
+The number of repetitions can be set with the following command.
+
+```
+\set repeat 3
+```
+
+#### Timeout
+
+In the unlikely event of a long-running query, you may want to set a query time after which the query is terminated
+automatically.
+This can be accomplished with our timeout setting.
+This setting specifies the timeout in milliseconds, with 0 milliseconds disabling the timeout.
+
+```
+\set timeout 1000
+```
+
+
+## Performance statistics commands
+
+In interactive mode, you can enable timing of commands using:
+```
+\timing on
+```
+
+To record our performance statistics, you can create a CSV with our performance results.
+Just specify the output CSV with the following setting.
+
+```
+\record path/to/perf.csv
+```
+
+The output of the queries can be redirected to files (or `/dev/null`).
+
+```
+\o path/to/output
+```
+

--- a/content/references/advanced/gs.md
+++ b/content/references/advanced/gs.md
@@ -1,5 +1,6 @@
 ---
 title: Tables on Google Cloud Storage
+weight: 10
 ---
 
 

--- a/content/references/advanced/pgvector.md
+++ b/content/references/advanced/pgvector.md
@@ -1,5 +1,6 @@
 ---
 title: Pgvector Extension
+weight: 20
 ---
 
 CedarDB supports working with vectors using the syntax from the [pgvector

--- a/content/references/advanced/prepare.md
+++ b/content/references/advanced/prepare.md
@@ -1,5 +1,6 @@
 ---
 title: Prepared Statements
+weight: 10
 ---
 
 Prepared statements allow you to declare an SQL statement *template* ahead of time once and execute it many times over later on.
@@ -47,9 +48,9 @@ query = "select * from users where name =" + username;
 **Safe, with prepared statements**:
 ```sql
 prepare lookupuser as select * from users where name = $1;
-execute lookupuser('alonso;drop table users'); 
--- the whole string is interpreted as name, 
--- the attacker cannot escape the query! 
+execute lookupuser('alonso;drop table users');
+-- the whole string is interpreted as name,
+-- the attacker cannot escape the query!
 ```
 
 ### Increase performance

--- a/content/references/advanced/s3.md
+++ b/content/references/advanced/s3.md
@@ -1,5 +1,6 @@
 ---
 title: Tables on AWS S3
+weight: 10
 ---
 
 CedarDB supports processing data from disaggregated storage.

--- a/content/references/configuration.md
+++ b/content/references/configuration.md
@@ -9,12 +9,49 @@ benchmark results, and highlight some of our expert configuration options.
 Usually, configuring these options is unnecessary, as CedarDB uses strategies to automatically choose the best settings
 for you.
 
+## Logging
+
+CedarDB prints log messages to the standard error output stream (stderr, fd 2).
+Depending on how you run CedarDB, the log messages will be printed to the terminal or your service manager.
+
+When running CedarDB directly in Bash, you can redirect all log messages to a log file:
+
+```bash
+./cedardb mydb 2>> cedardb.log
+```
+
+When running CedarDB in Docker, you can access the log of the container:
+
+```sh
+docker logs cedardb_test
+```
+
+When running CedarDB with systemd, you can access the logs using from the journal:
+
+```sh
+journalctl -u cedardb
+```
+
+### Log Verbosity
+
+In the default configuration, CedarDB logs few messages, i.e., mainly error messages.
+For troubleshooting, it can be helpful to increase the verbosity:
+
+```sql
+set verbosity = 'log';
+```
+
+In this verbosity, many messages are sent to the log.
+This can have a noticeable impact on performance, and can generate lots of log messages.
+Especially in high-traffic instances, verbosity should be kept low.
+For more infos on the log verbosity options, you can get more information in the [PostgreSQL guide](https://www.postgresql.org/docs/current/runtime-config-logging.html#RUNTIME-CONFIG-SEVERITY-LEVELS).
+
 ## Resource usage
 
 ### Memory usage
 
 By default, CedarDB uses 45% of available system memory for its buffer manager and 45% as working memory during query processing.
-If you are running applications beside CedarDB on your machine (e.g., your IDE or your browser) 
+If you are running applications beside CedarDB on your machine (e.g., your IDE or your browser)
 while doing heavy query processing on big datasets, you may want to reduce this amount.
 
 Unlike all other settings, this setting must be set before starting CedarDB.
@@ -47,73 +84,6 @@ To change the parallelism, simply query the database with the following PostgreS
 set debug.parallel=8;
 ```
 
-## Benchmarking
-
-### Repetition of queries
-
-To validate performance, it is important to run queries multiple times.
-To repeat a query, you can either repeat the execution (`e`), the compilation (`c`), or both (`a`).
-To change the repetition mode, simply query this command.
-
-```sql
-set debug.repeatmode='a';
-```
-
-The number of repetitions can be set with the following command.
-
-```sql
-set debug.repeat=3;
-```
-
-### Timeout
-
-In the unlikely event of a long-running query, you may want to set a query time after which the query is terminated
-automatically.
-This can be accomplished with our timeout setting.
-This setting specifies the timeout in milliseconds, with 0 milliseconds disabling the timeout.
-
-```sql
-set debug.timeout=1000;
-```
-
-## SQL tool
-
-When you run our sql tool, we have additional commands that will help you benchmark our system.
-
-### General commands
-
-For a list of possible commands, use our help command.
-
-```
-\?
-```
-
-If you want to specify a query that is stored in a file, you can load and run the query with our input command.
-
-```
-\i path/to/query.sql
-```
-
-### Performance statistics commands
-
-In interactive mode, you can enable timing of commands using:
-```
-\timing on
-```
-
-To record our performance statistics, you can create a CSV with our performance results.
-Just specify the output CSV with the following setting.
-
-```
-\record path/to/perf.csv
-```
-
-The output of the queries can be redirected to files (or `/dev/null`).
-
-```
-\o path/to/output
-```
-
 ## Advanced configuration
 
 Although these settings are usually determined automatically, we will briefly discuss some of our advanced settings.
@@ -137,57 +107,5 @@ We provide several compilation backends:
   superior execution performance.
 
 ```sql
-set debug.compilationmode='a';
+set compilationmode='a';
 ```
-
-### Multiway joins
-
-In addition to binary joins, CedarDB also implements multiway joins.
-These joins are particularly useful for graph workloads.
-Because most workloads do not benefit from these types of joins, we use them conservatively.
-If your workload does benefit from such joins, you can direct the database system to use them more actively with the
-following options:
-
-- Cautious `c`: Conservatively use multiway joins only when these joins clearly outperform binary joins (default).
-- Eager `e`: Use multiway joins more aggressively when the estimated runtime is slightly improved.
-- Disabled `d`: Allows only binary joins.
-
-```sql
-set debug.multiway='c';
-```
-
-### Logging
-
-CedarDB prints log messages to the standard error output stream (stderr, fd 2).
-Depending on how you run CedarDB, the log messages will be printed to the terminal or your service manager.
-
-When running CedarDB directly in Bash, you can redirect all log messages to a log file:
-
-```bash
-./cedardb mydb 2>> cedardb.log
-```
-
-When running CedarDB in Docker, you can access the log of the container:
-
-```sh
-docker logs cedardb_test
-```
-
-When running CedarDB with systemd, you can access the logs using from the journal:
-
-```sh
-journalctl -u cedardb
-```
-
-#### Log Verbosity
-
-In the default configuration, CedarDB logs few messages, i.e., mainly error messages.
-For troubleshooting, it can be helpful to increase the verbosity:
-
-```sql
-set debug.verbosity = 'debug5';
-```
-
-In this debug verbosity, all client messages and commands are sent to the log.
-This can have a noticeable impact on performance, and can generate lots of log messages.
-Especially in high-traffic instances, verbosity should be kept low.


### PR DESCRIPTION
We don't want to have debug. settings anymore in our docs. The shell was not part of the configuration and was already described in starting locally. It is also better to first describe the server mode than the interactive one.