### PR TITLE
Add missing index entry to PostgreSQL  functions page

### DIFF
--- a/content/references/sqlreference/functions/_index.md
+++ b/content/references/sqlreference/functions/_index.md
@@ -25,5 +25,5 @@ Functions are usually type specific, but are often overloaded to work with diffe
 * Miscellaneous functions
   * generate_series
   * tablesample
-  * PostgreSQL support (`pg_`)
+  * [PostgreSQL support (`pg_`)](./pg_functions)
 * [Advanced functions](./advanced_functions)

--- a/content/references/sqlreference/functions/pg_functions.md
+++ b/content/references/sqlreference/functions/pg_functions.md
@@ -1,9 +1,9 @@
 ---
-title: "Reference: PostgreSQL Administration Functions"
-linkTitle: "PostgreSQL Administration Functions"
+title: "Reference: PostgreSQL Functions"
+linkTitle: "PostgreSQL Functions"
 ---
 
-CedarDB supports a variety of PostgreSQL administration functions. This page currently only describes a prominent subset of those functions.
+CedarDB supports a variety of PostgreSQL functions. This page currently only describes a prominent subset of those functions.
 
 ## Advisory Locks
 


### PR DESCRIPTION
I removed "administration" adjective from the page title to make it more generic as we don't have a focus on "administration" ones