### PR TITLE
updated documentation of delete

### DIFF
--- a/content/references/sqlreference/statements/delete.md
+++ b/content/references/sqlreference/statements/delete.md
@@ -29,7 +29,19 @@ corresponding channel information.
 ```sql
 delete from pending_notifications n
 using channels c
-where n.reciever_id = $1
+where n.receiver_id = $1
   and n.channel_id = c.id
 returning *;
+```
+
+Scans in the returning clause read the database after the delete is completed.
+That is why the exists statement in the returning clause does not match the deleted row with itself in the following example.
+```sql
+delete from users
+where users.user_id = 42
+returning users.user_id, exists (select * from users where users.user_id=42);
+
+user_id | ?column? 
+--------+----------
+  42     | f
 ```


### PR DESCRIPTION
As requested, I updated the docu to reflect the behaviour of the returning-statement in delete. We may want to adapt the example to something more meaningful once cascading deletes are no longer hidden behind a feature flag.