### PR TITLE
Add Styleguide and Structure readmes

### DIFF
--- a/Structure.md
+++ b/Structure.md
@@ -1,0 +1,351 @@
+# CedarDB Documentation Content Structure
+
+How documentation is organized, where content belongs, and how to decide
+where new pages go.
+
+---
+
+## Top-Level Layout
+
+```
+content/
+├── _index.md                    # Landing page
+├── community_edition.md         # Community edition info
+├── technology.md                # Architecture and internals
+├── roadmap.md                   # Feature roadmap
+├── database_upgrade.md          # Upgrade procedures
+├── licensing.md                 # License information
+├── releases.md                  # Release notes
+│
+├── get_started/                 # First-time setup
+├── cookbook/                    # Task-oriented how-to guides
+├── example_datasets/            # Worked examples with real data
+├── clients/                     # Drivers, ORMs, GUI tools (see below)
+├── best_practices/              # Optimization, strengths, recommendations
+├── references/                  # Feature reference (see below)
+├── compatibility/               # PostgreSQL compatibility matrices
+```
+
+---
+
+## Section Purposes
+
+### get_started/
+
+First-time setup. Get CedarDB running as fast as possible.
+
+One page per deployment method (Docker, local install, cloud). Minimal
+explanation. Link to reference pages for deeper understanding. Do not add
+feature documentation here.
+
+### cookbook/
+
+Task-oriented guides answering "how do I do X with CedarDB?"
+
+One page per task. Each page is self-contained: the reader follows it from
+top to bottom and completes the task without consulting other pages. Include
+prerequisites at the top.
+
+Add a page when a task involves multiple steps, requires specific tooling,
+or combines multiple features in a non-obvious way. Simple single-feature
+usage belongs in the reference section.
+
+Name pages with verb phrases: "Importing from PostgreSQL", "Working with
+CSV Files", "Replicating via Debezium."
+
+### example_datasets/
+
+In-depth worked examples with real or realistic datasets. Demonstrate
+CedarDB capabilities (especially HTAP, mixed workloads, analytical queries
+over transactional data). These are showcases, not primary references. Link
+to reference pages for feature details.
+
+### clients/
+
+Organized into three sub-sections:
+
+- **Language folders** (`python/`, `javascript/`, `java/`, etc.) — one folder per
+  programming language. The folder's `_index.md` covers the primary driver or
+  adapter for that language. Additional pages in the same folder cover
+  language-specific ORMs and frameworks (e.g., `javascript/drizzle.md`).
+- **`tools/`** — GUI clients, CLI tools, and observability integrations that are
+  not tied to a specific programming language (DBeaver, DataGrip, psql, Grafana).
+
+Each page covers installation, connection setup, and a minimal working example.
+Focus on what is specific to CedarDB. Do not rewrite the client library's own
+documentation.
+
+Add a new language folder when a language gets its first client page. Add
+further pages within the folder as additional drivers, ORMs, or frameworks are
+documented for that language. Language-specific ORMs always live inside the
+relevant language folder, not in a separate top-level ORMs section.
+
+### best_practices/
+
+Optimization guidelines, recommended patterns, and where CedarDB excels.
+Separate from reference docs. May highlight strengths and include benchmarks.
+Cover topics like query optimization, schema design for HTAP workloads, bulk
+loading strategies, and when to use CedarDB-specific features.
+
+### clients/ layout
+
+```
+clients/
+├── python/
+│   └── _index.md            # psycopg driver
+├── javascript/              # Node.js / TypeScript ecosystem
+│   ├── _index.md            # node-postgres (pg) driver
+│   ├── drizzle.md
+│   └── prisma.md
+├── java/
+│   └── _index.md            # JDBC driver
+├── rust/
+│   └── _index.md
+├── cpp/
+│   └── _index.md
+├── csharp/
+│   └── _index.md
+├── r/
+│   └── _index.md
+└── tools/                   # Not language-specific
+    ├── psql.md
+    ├── dbeaver.md
+    ├── datagrip.md
+    └── grafana.md
+```
+
+### references/
+
+Authoritative feature reference. Object-first organization (see below).
+
+### compatibility/
+
+At-a-glance PostgreSQL compatibility matrices. Lookup tables, not explanations.
+Every entry with a reference page must link to it. Use Yes / Partial / No.
+See the Styleguide for rules on maintaining accuracy.
+
+---
+
+## Reference Section: Object-First Organization
+
+DDL documentation is organized by database object, not by SQL command. All
+operations on an object (CREATE, ALTER, DROP) live on the same page or in
+tightly linked pages within the same directory.
+
+```
+references/
+├── datatypes/                   # One page per type family
+│   ├── _index.md
+│   ├── integer.md               # smallint, integer, bigint, serial variants
+│   ├── numeric.md               # numeric, decimal
+│   ├── float.md                 # real, double precision
+│   ├── text.md                  # text, varchar, char
+│   ├── boolean.md
+│   ├── date.md
+│   ├── time.md                  # time, time with time zone
+│   ├── timestamp.md             # timestamp, timestamp with time zone
+│   ├── interval.md
+│   ├── json.md                  # json, jsonb
+│   ├── array.md
+│   ├── uuid.md
+│   ├── bit.md                   # bit, bit varying
+│   ├── blob.md                  # bytea
+│   ├── vector.md                # pgvector-compatible
+│   └── enums.md                 # user-defined enum types
+│
+├── objects/                     # One page per database object
+│   ├── _index.md
+│   ├── tables.md                # CREATE, ALTER, DROP TABLE, constraints, partitioning
+│   ├── indexes.md               # CREATE, DROP INDEX, types, partial, expression
+│   ├── views.md                 # CREATE, DROP VIEW, materialized views, REFRESH
+│   ├── schemas.md               # CREATE, ALTER, DROP SCHEMA, search_path
+│   ├── databases.md             # CREATE, ALTER, DROP DATABASE
+│   ├── roles.md                 # CREATE, ALTER, DROP ROLE, GRANT, REVOKE
+│   ├── sequences.md             # CREATE, ALTER, DROP SEQUENCE, nextval, currval
+│   ├── functions.md             # CREATE, ALTER, DROP FUNCTION/PROCEDURE, DO, CALL
+│   ├── triggers.md              # CREATE, ALTER, DROP TRIGGER
+│   └── types.md                 # CREATE, ALTER, DROP TYPE, domains, enums, composites
+│
+├── sqlreference/
+│   ├── _index.md
+│   ├── queries/                 # SELECT query syntax (one page per clause)
+│   │   ├── _index.md
+│   │   ├── select.md            # SELECT clause, DISTINCT, column aliases
+│   │   ├── from.md              # FROM clause, all JOIN types, LATERAL
+│   │   ├── where.md             # WHERE clause, filter conditions
+│   │   ├── groupby.md           # GROUP BY, HAVING
+│   │   ├── orderby.md           # ORDER BY, LIMIT, OFFSET
+│   │   ├── with.md              # CTEs, recursive CTEs
+│   │   ├── setops.md            # UNION, INTERSECT, EXCEPT
+│   │   └── window.md            # Window functions, OVER clause
+│   ├── dml/                     # Data manipulation (one page per statement)
+│   │   ├── _index.md
+│   │   ├── insert.md            # INSERT INTO, INSERT ... SELECT
+│   │   ├── copy.md              # COPY TO / FROM
+│   │   ├── update.md            # UPDATE ... SET
+│   │   ├── delete.md            # DELETE FROM
+│   │   └── upsert.md            # INSERT ... ON CONFLICT (upsert / MERGE)
+│   ├── transactions.md          # BEGIN, COMMIT, ROLLBACK, savepoints, isolation levels
+│   └── expressions/             # SQL expression features
+│       ├── _index.md
+│       └── try.md               # CedarDB-specific TRY expression
+│
+├── functions/                   # One page per function category
+│   ├── _index.md
+│   ├── aggregation.md           # count, sum, avg, array_agg, string_agg, ...
+│   ├── window.md                # row_number, rank, lag, lead, ...
+│   ├── text.md                  # String functions and operators
+│   ├── timestamp.md             # Date/time functions
+│   ├── json.md                  # JSON/JSONB functions and operators
+│   ├── math.md                  # Mathematical functions
+│   ├── array.md                 # Array functions and operators
+│   ├── system.md                # pg_backend_pid, version, has_*_privilege, ...
+│   ├── bitstring.md             # Bit string functions
+│   └── conditional.md           # CASE, COALESCE, NULLIF, GREATEST, LEAST
+│
+├── advanced/                    # CedarDB-specific and non-standard features
+│   ├── _index.md
+│   ├── parquet.md               # Parquet import
+│   ├── s3.md                    # Tables on AWS S3
+│   ├── gs.md                    # Tables on Google Cloud Storage
+│   ├── pgvector.md              # Vector similarity search
+│   ├── asof_join.md             # AsOf join
+│   ├── prepare.md               # Prepared statements
+│   └── benchmarking.md          # Interactive benchmarking
+│
+├── configuration.md             # Server configuration parameters
+└── writecache.md                # Write caching behavior
+```
+
+### Why object-first?
+
+When a user is working with tables, they want to find CREATE TABLE, ALTER TABLE,
+constraints, and partitioning in one place. Command-first organization (separate
+pages for CREATE TABLE, ALTER TABLE, DROP TABLE) scatters related information
+and forces the reader to navigate multiple pages for a single concept.
+
+Object pages should use clear subsection headings for each operation (Creating,
+Altering, Dropping, etc.) so that readers who know the specific command can
+jump directly to it.
+
+---
+
+## Content Placement Decision Tree
+
+1. **Is it about a database object (table, index, view, role, schema, sequence, function, trigger, type)?**
+   Go to `references/objects/<object>.md`
+
+2. **Is it a data type?**
+   Go to `references/datatypes/<type>.md`
+
+3. **Is it a function or operator?**
+   Go to `references/functions/<category>.md`
+
+4. **Is it about a SELECT query clause (SELECT, FROM, JOIN, WHERE, GROUP BY, ORDER BY, CTE, set operations, window functions)?**
+   Go to `references/sqlreference/queries/<clause>.md`
+
+5. **Is it about writing data (INSERT, COPY, UPDATE, DELETE, upsert)?**
+   Go to `references/sqlreference/dml/<statement>.md`
+
+6. **Is it about transaction control?**
+   Go to `references/sqlreference/transactions.md`
+
+7. **Is it a CedarDB-specific feature with no PostgreSQL equivalent?**
+   Go to `references/advanced/<feature>.md`
+
+8. **Is it a configuration parameter?**
+   Go to `references/configuration.md`
+
+9. **Is it a multi-step procedure or integration task?**
+   Go to `cookbook/<task>.md`
+
+10. **Is it about connecting with a programming language driver or ORM?**
+    Go to `clients/<language>/_index.md` (driver) or `clients/<language>/<orm>.md` (ORM/framework).
+
+11. **Is it about a GUI client, CLI tool, or BI/observability integration?**
+    Go to `clients/tools/<tool>.md`
+
+12. **Is it an optimization guideline or recommended pattern?**
+    Go to `best_practices/<topic>.md`
+
+13. **Is it a compatibility status update?**
+    Go to `compatibility/<area>.md`
+
+14. **None of the above?**
+    Flag for team discussion. Do not create new top-level sections without agreement.
+
+---
+
+## Combining vs. Splitting
+
+### Combine when
+
+- Operations are on the same object (CREATE/ALTER/DROP TABLE on one page)
+- Features share a concept that needs explaining once (all integer variants
+  share overflow behavior and casting rules)
+- A feature has fewer than three distinct sub-topics
+
+### Split when
+
+- Each candidate page would stand alone: its own realistic schema, its own
+  example, its own PostgreSQL differences section. If separating two sections
+  leaves either without a self-contained example, keep them together.
+
+### Never
+
+- Do not create pages for features that are not supported
+- Do not create empty placeholder pages for planned features
+- Do not split compatibility matrices across multiple files per feature
+
+---
+
+## File Naming
+
+- Lowercase, snake_case when more than one word is needed (`asof_join.md`,
+  `importing_from_postgresql.md`). Single-word names have no separator (`tables.md`).
+- Object pages by object name: `tables.md`, `indexes.md`, `roles.md`
+- Data types by common name: `integer.md`, `json.md`, `text.md`
+- Function categories by domain: `aggregation.md`, `timestamp.md`, `json.md`
+- Cookbooks with descriptive slugs: `importing_from_postgresql.md`, `working_with_csv.md`
+- Language client folders by language name: `python/`, `javascript/`, `java/`
+- ORM pages within the language folder: `javascript/drizzle.md`, `javascript/prisma.md`
+- Tool pages by tool name: `tools/grafana.md`, `tools/dbeaver.md`
+
+---
+
+## Relationship Between Compatibility and Reference Pages
+
+The compatibility matrix and reference pages must stay in sync. They serve
+different purposes:
+
+- **Compatibility pages** answer "does CedarDB support X?" at a glance.
+  They are lookup tables, not explanations.
+- **Reference pages** answer "how do I use X?" with syntax, description,
+  and examples.
+
+When a feature's status changes:
+1. Update the compatibility matrix entry.
+2. Update (or create) the reference page.
+3. Both changes go in the same PR.
+
+Compatibility entries must link to the CedarDB reference page, never to
+PostgreSQL documentation.
+
+---
+
+## CedarDB-Specific vs. PG-Compatible Features
+
+Features that have a PostgreSQL equivalent live in the standard reference
+structure (`objects/`, `functions/`, `sqlreference/`). CedarDB-specific
+behavior or additions are noted inline using a "PostgreSQL Differences"
+section on the same page.
+
+Features with no PostgreSQL equivalent (AsOf Join, Write Caching, TRY
+expressions, cloud storage tables) live in `references/advanced/`. If a
+CedarDB-specific feature is closely related to a standard feature (e.g.,
+vector types are a data type), it may live in the standard location instead
+(`references/datatypes/vector.md`, `references/advanced/pgvector.md`).
+
+The guiding question: where would a user look for it? If they would look
+under "data types," put it there. If it is an entirely new concept, put it
+under "advanced."

--- a/Styleguide.md
+++ b/Styleguide.md
@@ -1,0 +1,321 @@
+# CedarDB Documentation Style Guide
+
+Style principles, page structure, and writing rules for all CedarDB documentation.
+
+---
+
+## 1. Audience and Tone
+
+### Who we write for
+
+Readers are technical: developers, DBAs, and data engineers comfortable with SQL
+and database concepts. Assume SQL familiarity. Do not explain foundational database
+concepts (what a table is, what a transaction does). Do explain what CedarDB does,
+how each feature works, and where behavior differs from PostgreSQL.
+
+### Tone
+
+Precise and factual. Think: a senior engineer explaining something clearly.
+Confident, concise, helpful. Never condescending. Neutral in reference docs.
+Strengths may be highlighted in best-practices content.
+
+### Voice
+
+- Address the reader as "you" -- most natural in tutorials, used sparingly in
+  reference descriptions.
+- Active voice by default. "CedarDB returns the result." Not "The result is
+  returned by CedarDB."
+- Never use "we" to describe product behavior. Use "CedarDB" or "the database."
+
+| Avoid | Prefer |
+|-------|--------|
+| We recommend creating an index before querying. | Create an index before querying for better performance. |
+| The user should call SELECT after INSERT. | Call SELECT after INSERT to verify the result. |
+| We fixed the bug in version 2.3. | CedarDB 2.3 fixes the issue where ... |
+| The result is returned by CedarDB. | CedarDB returns the result. |
+
+---
+
+## 2. Language and Formatting
+
+- **American English.** "analyze" not "analyse", "behavior" not "behaviour."
+- **Oxford comma.** "tables, views, and indexes."
+- **SQL keywords** in uppercase in both prose and code blocks: `SELECT`, `ALTER TABLE`.
+- **Backticks** for inline technical names: `statement_timeout`, `psql`, `pg_catalog`.
+- **"CedarDB"** (not "Cedar DB", "cedar"). **"PostgreSQL"** (not "Postgres", "PG")
+  in prose. Technical names like `pg_catalog` or `psql` are fine as-is.
+- **Page titles:** title case. **Subsection headings:** sentence case.
+- **Sentences:** keep them short. One idea per sentence. Under 25 words as a target.
+
+---
+
+## 3. Page Structure
+
+### 3.1 Reference pages
+
+Every SQL reference page follows this structure. Omit a section only if it
+genuinely does not apply. Do not leave sections empty or include placeholders.
+
+| Section | Required? | Purpose |
+|---------|-----------|---------|
+| One-paragraph summary | Yes | What the feature does. No examples yet. |
+| Quick example | Yes | Short, self-contained SQL showing the core concept. |
+| Syntax | Yes | Railroad diagram of the supported syntax, followed by a plain-text fallback block with `<placeholders>` and `[optional]` parts. Options listed as a table. |
+| Parameters and options | If applicable | Table of parameters, types, defaults, descriptions. |
+| Permissions | If applicable | Which roles can execute this and under what conditions. |
+| PostgreSQL differences | If any exist | Bulleted list of behavioral differences. See Section 5. |
+| Further examples | Recommended | Realistic scenarios covering edge cases. |
+
+Railroad diagrams are the primary way to communicate syntax. Use the
+`{{</* railroad */>}}` shortcode. Only document syntax that CedarDB actually
+supports — omit clauses that are not yet implemented rather than greying them
+out. Follow the diagram with a plain-text syntax block as a fallback for
+readers who prefer text, and as the source of truth for the options table below.
+
+### 3.2 Tutorial and cookbook pages
+
+Same opening structure (summary, quick example) but replace the formal syntax
+section with step-by-step instructions. Each step must be independently
+executable -- the reader should be able to copy-paste the code block for that
+step without needing to have read previous steps.
+
+Start with the simplest correct path (happy path first). Introduce complexity
+and edge cases later, clearly labeled.
+
+### 3.3 Compatibility pages
+
+Use tables with a traffic-light status column using inline emoji:
+
+| Status | Emoji | Meaning |
+|--------|-------|---------|
+| Full | 🟢 | Core PostgreSQL functionality works. |
+| Partial | 🟡 | Meaningful, commonly-used functionality is missing. |
+| No | 🔴 | The feature is not supported at all. |
+
+- Every entry with a reference page must link to it.
+- **Full** means core PostgreSQL functionality works. Minor missing sub-features
+  (edge-case options, rarely-used clauses) do not prevent a Full rating. Document
+  the gaps in the reference page's "PostgreSQL Differences" section, not here.
+- **Partial** means meaningful, commonly-used functionality is missing. Link to
+  the reference page only — do not list limitations inline in the matrix.
+- **No** means the feature is not supported at all.
+- All Partial and No entries must be verified by testing. Do not guess.
+- Never link to PostgreSQL docs from compatibility entries.
+
+### 3.4 Section index pages (_index.md)
+
+Every directory that groups related pages must have an `_index.md`. It serves
+as the landing page for that section in the navigation and is the first thing
+a reader sees when arriving at a section from a search result or a cross-link.
+
+Structure:
+
+| Part | Required? | Notes |
+|------|-----------|-------|
+| One-paragraph overview | Yes | What this section covers and why it exists as a group. No syntax, no examples. |
+| Member list | Yes | A bulleted or linked list of all pages in the section, each with a one-line description. |
+
+Keep the overview to two or three sentences. It should answer "what will I find
+here?" and orient the reader before they click into a specific page. Do not
+repeat the section title verbatim as the first sentence.
+
+The member list must stay in sync with the actual pages in the directory. When
+a page is added or removed, update the `_index.md` in the same PR.
+
+Example:
+
+```markdown
+CedarDB supports the standard SQL data types, with extensions for analytical
+workloads. Each page covers the type's storage format, valid ranges, casting
+rules, and any differences from PostgreSQL.
+
+- [Integer types](integer) — `smallint`, `integer`, `bigint`, and serial variants
+- [Numeric](numeric) — arbitrary-precision `numeric` and `decimal`
+- [Text](text) — `text`, `varchar`, and `char`
+- [JSON](json) — `json` and `jsonb` with operator and function reference
+```
+
+### 3.5 Best-practices pages
+
+Separate from reference docs. Cover where CedarDB excels, known limitations
+with recommended workarounds, and optimization guidelines. May highlight
+strengths. Include benchmarks or explanations where relevant.
+
+---
+
+## 4. Examples
+
+### Rules
+
+1. **Self-contained.** Include the CREATE TABLE or equivalent setup needed to
+   run the example. Do not assume state from elsewhere in the docs.
+2. **Copy-pasteable.** The code block runs without modification in a CedarDB
+   psql session.
+3. **Show expected output** when the result is non-obvious or demonstrates
+   specific behavior. Use the psql tabular format in a separate code block
+   or as comments.
+4. **No cross-page running examples.** Each page uses its own schema. Do not
+   build on tables defined in other pages.
+5. **Consistent naming theme.** Use plant and tree themed names where they fit
+   naturally: `trees`, `forests`, `plants`, `species`, `growth_rate`, `height`,
+   `bloom_date`. Fall back to other realistic domain names (`orders`, `customers`,
+   `amount`) when a botanical theme would feel forced for the concept being
+   demonstrated. Never use meaningless names like `t`, `a`, `b`, `foo`.
+6. **One concept per example.** Do not combine unrelated features.
+7. **Keep it short.** Under 10 lines preferred. 15 lines maximum for complex
+   features (transactions with savepoints, multi-step migrations).
+
+### Pattern
+
+```sql
+-- Create the table
+CREATE TABLE trees (
+    id          integer PRIMARY KEY,
+    species     text    NOT NULL,
+    height_m    numeric NOT NULL,
+    planted     date    DEFAULT current_date
+);
+
+-- Insert a row
+INSERT INTO trees VALUES (1, 'Oak', 12.4, '2015-03-10');
+
+-- Verify
+SELECT * FROM trees;
+--  id | species | height_m |  planted
+-- ----+---------+----------+------------
+--   1 | Oak     |     12.4 | 2015-03-10
+```
+
+---
+
+## 5. PostgreSQL Compatibility Handling
+
+### Framing
+
+CedarDB is PostgreSQL-compatible. Many readers arrive with PostgreSQL knowledge.
+Leverage that, but never send readers away to read PostgreSQL docs.
+
+**No external PostgreSQL links.** Never link to postgresql.org. If the reader
+needs more context, document it in CedarDB docs. Linking externally signals
+immaturity and causes drop-off.
+
+### Highlighting additions
+
+When CedarDB extends PostgreSQL, call it out positively: "In addition to standard
+PostgreSQL behavior, CedarDB also supports ..." Do not frame additions as edge
+cases.
+
+### Differences on reference pages
+
+If a reference page has any behavioral difference from PostgreSQL, include a
+"PostgreSQL Differences" section. Use a bulleted list. If there are no
+differences, omit the section entirely.
+
+```markdown
+## PostgreSQL Differences
+
+- `ON CONFLICT DO UPDATE` is supported; `ON CONFLICT DO NOTHING` is not yet available.
+- The `RETURNING` clause supports all column expressions.
+```
+
+### Features first, limitations second
+
+Lead with what CedarDB can do. Limitations and PostgreSQL differences belong in
+a clearly labeled section near the bottom of the page, not in a warning at the top.
+
+| Avoid | Prefer |
+|-------|--------|
+| Warning: CedarDB does not support X. | CedarDB supports Y and Z. Note: X is not yet available; see the roadmap. |
+| Partial support only -- see caveats. | Fully supported. The following options are not yet available: [list] |
+
+---
+
+## 6. Self-Contained Documentation
+
+The CedarDB docs must function as a complete reference. Readers should never need
+to leave the site to understand how to use a feature.
+
+- Do not link to external documentation to explain a concept. Document it here.
+- Internal cross-links are encouraged. Link to related CedarDB pages freely.
+- If a concept needs context (e.g., what snapshot isolation means), explain it
+  briefly in the description section rather than linking elsewhere.
+
+---
+
+## 7. What to Document
+
+### Prioritize breadth over depth
+
+A complete set of documentation, even for simple features, signals project maturity.
+Do not skip documenting something because it seems basic or obvious.
+
+Enterprise evaluators check for completeness, not sophistication. Document the
+boring stuff.
+
+### What not to document
+
+- Features that are not yet implemented. The roadmap covers planned work.
+- Internal implementation details unless they affect user-visible behavior.
+- Workarounds for missing features. If a feature is missing, say so and stop.
+
+---
+
+## 8. Versioning
+
+CedarDB does not maintain versioned documentation. All documentation describes
+the current stable release. Versioned docs encourage users to stay on old
+versions and create back-porting pressure.
+
+When features change between versions, update the existing page. Release notes
+in `releases.md` track what changed per version.
+
+---
+
+## 9. Maintenance
+
+### Docs before code merge
+
+Documentation must be written and approved before the corresponding code change
+is merged. Submit a documentation PR alongside the code PR. The documentation PR
+must be approved before the code PR can be merged.
+
+### Fixing stale docs
+
+If you discover a mismatch between docs and behavior during routine development,
+fix it immediately in the same PR. Do not file "fix docs later" tickets.
+
+---
+
+## 10. Code Blocks
+
+- SQL code blocks use the `sql` language tag.
+- Shell commands use `bash` or no tag. Prefix with `$` only when mixing commands
+  with output.
+- Syntax definitions use no language tag. Use `<angle brackets>` for placeholders
+  and `[square brackets]` for optional parts.
+
+---
+
+## 11. Admonitions and Tables
+
+- Use Hugo admonitions sparingly. Two types: info (supplementary context) and
+  warning (behavior that might surprise the reader or cause data loss).
+- Limit to one admonition per page section. If you need more, revise the prose
+  to incorporate the information directly.
+- Use markdown tables for structured information. Keep cells simple. If a cell
+  needs more than one sentence, use prose instead.
+
+---
+
+## Quick Reference
+
+| Avoid | Prefer |
+|-------|--------|
+| Link to postgresql.org for more detail. | Document the detail here. |
+| Put limitations in a callout at the top. | Lead with what the feature does; limitations at the bottom. |
+| Write "we" for product behavior. | Write "CedarDB" or "the database." |
+| Assume readers have context from another page. | Make every example self-contained. |
+| Skip documenting simple features. | Document everything. Completeness signals maturity. |
+| Leave "No" entries in the compatibility matrix untested. | Test it. Update the entry. Update the reference page. |
+| Use passive voice by default. | Use active voice. |
+| Commit audit results to main. | Always commit on a dated branch. |


### PR DESCRIPTION
Add readmes to describe the intended structure of the repository as a whole, and a styleguide on how each individual page should be written.

We will restructure the current docs according to these guides and, going forward, new pages should adhere to them.