### PR TITLE
Add docs for prisma studio

### DIFF
--- a/content/clients/javascript/prisma.md
+++ b/content/clients/javascript/prisma.md
@@ -202,6 +202,16 @@ All users:  [
 ]
 ```
 
+## Prisma Studio
+
+To browse and edit your data visually, run:
+
+```shell
+npx prisma studio
+```
+
+This opens a browser UI using the connection string from `.env`.
+
 ## Known Limitations
 
 CedarDB's Prisma support is actively being developed. The following are known limitations:


### PR DESCRIPTION
As soon as cedardb/cedardb#3360 is merged and released, we can run prisma studio. Since the current available prisma studio version does not support DDL, we actually support all of the features of it!