### PR TITLE
Fix broken links from refactoring

### DIFF
--- a/content/compatibility/sql_features.md
+++ b/content/compatibility/sql_features.md
@@ -11,7 +11,7 @@ This page gives a **non-exhaustive** overview of currently supported core SQL fu
 CedarDB strives for full PostgreSQL compatibility, and features not currently supported will be added over time.
 
 For PostgreSQL-specific functionality, such as system table support, see
-the [system table compatibility](../system-table) page.
+the [system table compatibility](../system_table) page.
 
 ## Data Definition
 
@@ -154,7 +154,7 @@ the [system table compatibility](../system-table) page.
 | cidr                                    | No                |                                                                 |
 | circle                                  | No                |                                                                 |
 | date                                    | Yes               |           [Date Documentation](/docs/references/datatypes/date) |
-| double precision                        | Yes               |       [Double Documentation](/docs/references/datatypes/double) |
+| double precision                        | Yes               |        [Double Documentation](/docs/references/datatypes/float) |
 | inet                                    | No                |                                                                 |
 | integer                                 | Yes               |     [Integer Documentation](/docs/references/datatypes/integer) |
 | interval [ fields ] [ (p) ]             | Yes               |   [Interval Documentation](/docs/references/datatypes/interval) |
@@ -171,7 +171,7 @@ the [system table compatibility](../system-table) page.
 | pg_snapshot                             | No                |                                                                 |
 | point                                   | No                |                                                                 |
 | polygon                                 | No                |                                                                 |
-| real                                    | Yes               |       [Double Documentation](/docs/references/datatypes/double) |
+| real                                    | Yes               |         [Float Documentation](/docs/references/datatypes/float) |
 | smallint                                | Yes               |     [Integer Documentation](/docs/references/datatypes/integer) |
 | smallserial                             | Yes               |                                                                 |
 | serial                                  | Yes               |                                                                 |

--- a/content/references/datatypes/float.md
+++ b/content/references/datatypes/float.md
@@ -81,7 +81,7 @@ select sum(i::double precision) from x;
 (1 row)
 ```
 
-With exact-precision [`numeric`](numeric) types, the result of the query would be 0.
+With exact-precision [`numeric`](../numeric) types, the result of the query would be 0.
 However, with `double precision`, the result is only *close to* zero.
 
 The result also is not stable, i.e., can change indeterministically when repeated:

--- a/content/references/dml/delete.md
+++ b/content/references/dml/delete.md
@@ -14,7 +14,7 @@ where status = 'canceled';
 
 We recommend always specifying a `where` clause for delete statements.
 If you want to delete all rows of a table, consider using
-[`truncate`](./truncate) instead.
+[`truncate`](../truncate) instead.
 
 ## Returning Deleted Rows
 

--- a/content/references/dml/insert.md
+++ b/content/references/dml/insert.md
@@ -13,7 +13,7 @@ values ('Barbie', 2023, 114, 'Comedy'),
        ('The Boy and the Heron', 2023, 124, 'Anime');
 ```
 
-When inserting many values verbatim, consider using a [copy statement](./copy)
+When inserting many values verbatim, consider using a [copy statement](../copy)
 instead to reduce parsing overhead.
 
 You can also insert rows from the result of arbitrary queries:
@@ -46,7 +46,7 @@ values (1, 'Chris'), (2, 'Philipp')
 on conflict do nothing;
 ```
 
-You can find the full documentation for `on conflict` in the [upsert reference](./upsert).
+You can find the full documentation for `on conflict` in the [upsert reference](../upsert).
 
 ## Returning
 

--- a/content/references/dml/truncate.md
+++ b/content/references/dml/truncate.md
@@ -12,7 +12,7 @@ truncate movies, stars, starsIn;
 ```
 
 This removes all rows from the specified tables, similar to an unqualified
-[delete](./delete).
+[delete](../delete).
 
 {{< callout type="warning" >}}
 Truncate is a **destructive** operation and will cause all data in the specified tables to be lost.

--- a/content/references/dml/upsert.md
+++ b/content/references/dml/upsert.md
@@ -3,7 +3,7 @@ title: "Reference: Upsert Statement"
 linkTitle: "Upsert"
 ---
 
-Upserts allow [inserting](./insert) values into tables with a custom [update](./update) logic that will be applied to
+Upserts allow [inserting](../insert) values into tables with a custom [update](../update) logic that will be applied to
 conflicting existing values.
 This allows, e.g., idempotent inserts, or to keep track of stateful data without knowledge of the previous state.
 
@@ -57,7 +57,7 @@ Alternatively, you can specify the constraint using its name, e.g., `userId_pkey
 
 A query can reference both the existing value and the not-inserted value in the `do update` clause.
 The non-inserted value can be accessed via the temporary `excluded` table, and can be combined with an arbitrary
-expression, including subselects (similar to [Updates](./update)).
+expression, including subselects (similar to [Updates](../update)).
 
 A trailing `returning` clause will then return final value in the table, so either the inserted one, or the result of
 the update.

--- a/content/references/queries/select.md
+++ b/content/references/queries/select.md
@@ -14,7 +14,7 @@ select name, length from movies where id = 42;
 For fast single-element access with `where`, consider specifying `id` as primary key or adding an explicit index.
 {{< /callout >}}
 
-You can also use [expressions](../expressions) or [functions](/docs/references/functions) to transform your data:
+You can also use [expressions](../../expressions) or [functions](/docs/references/functions) to transform your data:
 ```sql
 select date_trunc('month', release_date) from movies;
 ```

--- a/content/references/sessions/discard.md
+++ b/content/references/sessions/discard.md
@@ -17,7 +17,7 @@ discard all;
 * `all`
   Discard all session state. This includes [prepared statements](/docs/references/advanced/prepare),
   [temporary tables](/docs/references/objects/tables/#options), and
-  [session settings](./settings).
+  [session settings](../settings).
   After a discard all, the session behaves like a fresh connection.
   This is useful when a connection is shared between multiple client threads that all depend on having a pristine
   connection.

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,48 @@
+{{- $destClean := strings.Trim .Destination "()" -}}
+{{- $u := urls.Parse $destClean -}}
+{{- $basePath := (urls.Parse site.BaseURL).Path -}}
+
+{{- if and (not (strings.HasPrefix $destClean "http")) (not (hasPrefix $u.Path "HAHAHUGOSHORTCODE")) -}}
+  {{- with $u.Path -}}
+
+    {{- /* Resolve to a content-root-relative path. Absolute paths strip the base prefix;
+           relative paths are joined against the page's rendered URL first. */}}
+    {{- $rel := "" -}}
+    {{- $relInner := "" -}}
+    {{- if hasPrefix . "/" -}}
+      {{- $rel = strings.TrimRight "/" (strings.TrimPrefix $basePath .) -}}
+      {{- $relInner = $rel -}}
+    {{- else -}}
+      {{- $rel      = strings.TrimRight "/" (strings.TrimPrefix $basePath (path.Join $.Page.RelPermalink .)) -}}
+      {{- $relInner = strings.TrimRight "/" (strings.TrimPrefix $basePath (path.Join $.PageInner.RelPermalink .)) -}}
+    {{- end -}}
+
+    {{- /* Discard if resolution escaped the content root (e.g. wrong page context from
+           markdownify inside a shortcode). */}}
+    {{- if or (hasPrefix $rel      "/") (hasPrefix $rel      "..") -}}{{- $rel = "" -}}{{- end -}}
+    {{- if or (hasPrefix $relInner "/") (hasPrefix $relInner "..") -}}{{- $relInner = "" -}}{{- end -}}
+
+    {{- /* Accept the link if either resolution finds a page. Page and PageInner differ
+           when a section _index.md is processed — trying both avoids false positives. */}}
+    {{- $p := or (site.GetPage $rel) (site.GetPage $relInner) -}}
+    {{- if $p -}}
+      {{- with $u.Fragment -}}
+        {{- if not ($p.Fragments.Identifiers.Contains .) -}}
+          {{- warnf "Broken anchor '#%s' on page '%s' (linked from %s)" . $u.Path $.PageInner.File.Path -}}
+        {{- end -}}
+      {{- end -}}
+    {{- else if or $rel $relInner -}}
+      {{- warnf "Broken internal link '%s' in %s" $u.Path $.PageInner.File.Path -}}
+    {{- end -}}
+
+  {{- else -}}
+    {{- with $u.Fragment -}}
+      {{- if not ($.PageInner.Fragments.Identifiers.Contains .) -}}
+        {{- warnf "Broken same-page anchor '#%s' in %s" . $.PageInner.File.Path -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- with . -}}
+  <a href="{{ .Destination | safeURL }}" {{ with .Title }}title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }}target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>
+{{- end -}}


### PR DESCRIPTION
This PR adds a link-checker utility and also fixes all broken links that could be easily fixed.

Not fixed broken links:
 - row_level_security-link in compatibility/_index.html since this page does not seem to exist.
 - invalid ancors from compatibility/sql_features.md since the referenced items do not exist.