### PR TITLE
serve releasenotes.json at docs/releasenotes.json

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -49,6 +49,16 @@ menu:
       params:
         icon: github
 
+outputFormats:
+  ReleasenotesJSON:
+    mediaType: "application/json"
+    baseName: "releasenotes"
+    isPlainText: true
+    notAlternative: true
+
+outputs:
+  home: [html, rss, ReleasenotesJSON]
+
 markup:
   highlight:
     noClasses: false

--- a/layouts/index.releasenotesjson.json
+++ b/layouts/index.releasenotesjson.json
@@ -1,0 +1,1 @@
+{{ $.Site.Data.releasenotes | jsonify }}


### PR DESCRIPTION
Can be used by tools like keeper to render the changelog without having to parse HTML.