### PR TITLE
Add finished parquet reader to roadmap

### DIFF
--- a/content/references/advanced/parquet.md
+++ b/content/references/advanced/parquet.md
@@ -201,7 +201,7 @@ This page summarizes the available features supported by the CedarDB Parser.
 |      Compression      | Support |
 |:---------------------:|:-------:|
 | UNCOMPRESSED          |   🟢    |
-| BROTLI                |   🔴    |
+| BROTLI                |   🟢    |
 | GZIP                  |   🟢    |
 | LZ4 (deprecated)      |   🔴    |
 | LZ4_RAW               |   🟢    |

--- a/content/roadmap.md
+++ b/content/roadmap.md
@@ -50,7 +50,7 @@ CedarDB.
 
 | **Feature**           |       **State**        | **Details**                                                |
 |-----------------------|:----------------------:|------------------------------------------------------------|
-| Parquet reader        |  {{< iconplanned >}}   |                                                            |
+| Parquet reader        |    {{< icondone >}}    | [Documentation](/docs/references/advanced/parquet/)        |
 | Parquet writer        |  {{< iconplanned >}}   |                                                            |
 | Iceberg support       |  {{< iconplanned >}}   |                                                            |
 | pg_dump compatibility | {{< iconinprogress >}} | [Documentation](/docs/cookbook/importing_from_postgresql/) |


### PR DESCRIPTION
Cedar has a working parquet reader with brotli support.